### PR TITLE
Chaluli/fix swapped resources and principals

### DIFF
--- a/cedar-policy-mcp-schema-generator/src/schema_generator.rs
+++ b/cedar-policy-mcp-schema-generator/src/schema_generator.rs
@@ -655,11 +655,8 @@ impl SchemaGenerator {
                     let attr_name = property.name().to_smolstr();
                     let ty_name = property.name().parse()?;
 
-                    let ty = self.cedar_type_from_property_type(
-                        namespace,
-                        ty_name,
-                        property.property_type(),
-                    )?;
+                    let ty =
+                        self.cedar_type_from_property_type(&ns, ty_name, property.property_type())?;
                     let ty = TypeOfAttribute {
                         ty,
                         annotations: Annotations::new(),


### PR DESCRIPTION
## Description of changes

Fixes 2 issues in the schema generator. One which accidenally swaps principal and resource types on Action's applyspec. And one in which a sub-namespace was created but not passed down to recursive calls (possibly causing a name collision).

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to any crates.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

Does not update because changelog will be created for initial release (not tracking pre-release changes).