### PR TITLE
Avoid `unwrap` on `NonEmpty` constructor

### DIFF
--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -918,17 +918,10 @@ impl SchemaGenerator {
                 TypeVariant::Entity { name }
             }
             PropertyType::Enum { variants } => {
-                if variants.is_empty() {
-                    return Err(SchemaGeneratorError::empty_enum_choice(format!(
-                        "{ty_name}"
-                    )));
-                }
-                #[allow(clippy::unwrap_used, reason = "variants are not empty")]
-                // PANIC SAFETY: variants cannot be empty
+                let variants = NonEmpty::from_slice(variants)
+                    .ok_or_else(|| SchemaGeneratorError::empty_enum_choice(format!("{ty_name}")))?;
                 let ty = EntityType {
-                    kind: EntityTypeKind::Enum {
-                        choices: NonEmpty::from_vec(variants.clone()).unwrap(),
-                    },
+                    kind: EntityTypeKind::Enum { choices: variants },
                     annotations: Annotations::new(),
                     loc: None,
                 };

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -918,10 +918,10 @@ impl SchemaGenerator {
                 TypeVariant::Entity { name }
             }
             PropertyType::Enum { variants } => {
-                let variants = NonEmpty::from_slice(variants)
-                    .ok_or_else(|| SchemaGeneratorError::empty_enum_choice(format!("{ty_name}")))?;
+                let choices = NonEmpty::from_slice(variants)
+                    .ok_or_else(|| SchemaGeneratorError::empty_enum_choice(ty_name.to_string()))?;
                 let ty = EntityType {
-                    kind: EntityTypeKind::Enum { choices: variants },
+                    kind: EntityTypeKind::Enum { choices },
                     annotations: Annotations::new(),
                     loc: None,
                 };


### PR DESCRIPTION
## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to any crates in this repository (e.g., changes to the signature of an existing API).
  * List all crates requiring a major version bump here
- [ ] A backwards-compatible change requiring a minor version bump to any crates in this repository (e.g., addition of a new API).
  * List all crates requiring a minor version bump here
- [ ] A bug fix or other functionality change requiring a patch to any crates.
- [ ] A change "invisible" to users (e.g., documentation, changes to non public-facing "internal" APIs)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.