### PR TITLE
add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,93 @@
+# This workflow is for releasing either:
+#.    - mcp-tools-sdk
+#.    - cedar-policy-mcp-schema-generator
+# Notes:
+# - This workflow must be triggered from the main branch.
+# - This workflow will perform the release from the provided tag, which must be set in advance.
+# - This workflow has two jobs:
+#.   + validate the parameter (runs from main, tag format, tag matches version in Cargo.toml)
+name: Publish Rust crate to crates.io
+on:
+    # This workflow must be triggered manually.
+    workflow_dispatch:
+        inputs:
+            crate:
+                required: true
+                type: choice
+                description: "The crate to publish"
+                options:
+                    - mcp-tools-sdk
+                    - cedar-policy-mcp-schema-generator
+            tag:
+                required: true
+                type: string
+                description: "The GitHub tag to be released. Must be of the form
+                    '<crate>-v<MAJOR>.<MINOR>.<PATCH>'"
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        steps:
+            # Check that this workflow was triggered from the 'main' branch.
+            - name: Validate branch
+              if: github.ref != 'refs/heads/main'
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+              with:
+                  script: core.setFailed('This workflow must be triggered from the "main"
+                      branch.')
+
+            # Check that the input tag is well-formed and matches the selected crate.
+            - name: Validate tag
+              run: |
+                  REGEX_PATTERN="^${CRATE_NAME}-v[0-9]+\.[0-9]+\.[0-9]+$"
+                  if [[ ! "$TAG_NAME" =~ $REGEX_PATTERN ]]; then
+                      echo "Specified tag must match $REGEX_PATTERN"
+                      exit 1
+                  fi
+              env:
+                  CRATE_NAME: ${{ inputs.crate }}
+                  TAG_NAME: ${{ inputs.tag }}
+
+            # Check that the cargo package's version matches the input tag.
+            - name: Checkout tag
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  ref: refs/tags/${{ inputs.tag }}
+            - name: Configure rust toolchain
+              run: rustup update stable && rustup default stable
+            - name: Install toml-cli
+              run: cargo install toml-cli --locked
+            - name: Validate package version
+              run: test "${CRATE_NAME}-v$(toml get --raw ./${CRATE_NAME}/Cargo.toml
+                  package.version)" = "$TAG_NAME"
+              working-directory: rust/
+              env:
+                  CRATE_NAME: ${{ inputs.crate }}
+                  TAG_NAME: ${{ inputs.tag }}
+
+    publish-crate:
+        # Only publish if validation succeeds.
+        needs: [ validate ]
+        runs-on: ubuntu-latest
+        environment: release
+        permissions:
+            id-token: write # Required for OIDC token exchange
+        steps:
+            - name: Checkout tag
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  ref: refs/tags/${{ inputs.tag }}
+            - name: Configure rust toolchain
+              run: rustup update stable && rustup default stable
+            - name: Authenticate with crates.io
+              id: auth
+              uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+            - name: Publish to crates.io
+              run: cargo publish -p "$CRATE_NAME"
+              working-directory: rust/
+              env:
+                  CRATE_NAME: ${{ inputs.crate }}
+                  CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This adds a `publish.yml` workflow for the crate `cedar-policy-mcp-schema-generator` and `mcp-tools-sdk`.  The `release` environment has been created.

We'll need to set up trusted publishing on crates.io if this is accepted.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to non public-facing "internal" APIs)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.