### PR TITLE
JSON schema tuples

### DIFF
--- a/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Adds the ability to convert a MCP tool request (and optionally response) to a Cedar request and entity data compliant to the generated Schema.
+- Adds support for JSON Schema tuples in MCP tool schemas, which are translated to a record of projections.
 
 ### Changed
 - Type arrays in MCP tool schemas now result in records of optional fields (encoding union of types), rather than records of projections (encoding tuples).

--- a/rust/cedar-policy-mcp-schema-generator/examples/simple/tool_mixed_array.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/simple/tool_mixed_array.cedarschema
@@ -1,0 +1,30 @@
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type mixed_array_toolInput = {
+    mixed_array?: Set<MyMcpServer::Unknown>
+  };
+
+  entity McpServer;
+
+  entity Unknown;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  action "call_tool";
+
+  action "mixed_array_tool" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: mixed_array_toolInput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/simple/tool_mixed_array.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/simple/tool_mixed_array.json
@@ -1,0 +1,17 @@
+{
+    "name": "mixed_array_tool",
+    "description": "a tool with a non-tuple open array using prefixItems",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "mixed_array": {
+                "type": "array",
+                "prefixItems": [
+                    { "type": "integer" },
+                    { "type": "string" }
+                ],
+                "items": { "type": "boolean" }
+            }
+        }
+    }
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/simple/tool_tuple.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/simple/tool_tuple.cedarschema
@@ -1,0 +1,38 @@
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type tuple_toolInput = {
+    coordinate?: {
+      proj0: MyMcpServer::Number,
+      proj1: MyMcpServer::Number
+    },
+    ids?: Set<String>,
+    labeled_value?: {
+      proj0: String,
+      proj1: Long
+    }
+  };
+
+  entity McpServer;
+
+  entity Number;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  action "call_tool";
+
+  action "tuple_tool" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tuple_toolInput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/simple/tool_tuple.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/simple/tool_tuple.json
@@ -1,0 +1,33 @@
+{
+    "name": "tuple_tool",
+    "description": "a tool with tuple inputs",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "coordinate": {
+                "type": "array",
+                "prefixItems": [
+                    { "type": "number" },
+                    { "type": "number" }
+                ],
+                "items": false
+            },
+            "labeled_value": {
+                "type": "array",
+                "prefixItems": [
+                    { "type": "string" },
+                    { "type": "integer" }
+                ],
+                "items": false
+            },
+            "ids": {
+                "type": "array",
+                "prefixItems": [
+                    { "type": "string" },
+                    { "type": "string" }
+                ],
+                "items": { "type": "string" }
+            }
+        }
+    }
+}

--- a/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
+++ b/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
@@ -77,6 +77,15 @@ mod lib {
             SchemaGeneratorConfig::default().flatten_namespaces(true),
         );
     }
+
+    #[test]
+    fn tuple_tool() {
+        run_integration_test(
+            "examples/simple/tool_tuple.json",
+            "examples/simple/tool_tuple.cedarschema",
+            SchemaGeneratorConfig::default(),
+        );
+    }
 }
 
 #[cfg(feature = "cli")]
@@ -477,6 +486,141 @@ mod cli {
             .arg(resource)
             .arg("--context")
             .arg(&context_fname)
+            .arg("--policies")
+            .arg(&policy_fname)
+            .arg("--entities")
+            .arg(&entities_fname)
+            .arg("--mcp-tool-input")
+            .arg(&input_fname);
+        cmd.unwrap().assert().success().stdout("DENY\n").stderr("");
+    }
+
+    #[test]
+    fn test_authorize_tuple_allow() {
+        let temp_dir = TempDir::new().unwrap();
+        let entities_fname = temp_dir.path().join("entities.json");
+        std::fs::write(&entities_fname, "[]").unwrap();
+
+        let request_json = r#"{
+    "principal": "MyMcpServer::User::\"test_user\"",
+    "resource": "MyMcpServer::McpServer::\"test_server\"",
+    "context": {
+        "session": {
+            "currentTimestamp": {
+                "__extn": {
+                    "fn": "datetime",
+                    "arg": "2025-12-16"
+                }
+            },
+            "ipaddr": {
+                "__extn": {
+                    "fn": "ip",
+                    "arg": "10.0.0.1"
+                }
+            }
+        }
+    }
+}"#;
+        let request_fname = temp_dir.path().join("request.json");
+        std::fs::write(&request_fname, request_json).unwrap();
+
+        let policy_fname = temp_dir.path().join("policies.cedar");
+        std::fs::write(
+            &policy_fname,
+            r#"permit(principal, action, resource) when {
+    context.input.coordinate.proj0 == decimal("1.0") &&
+    context.input.labeled_value.proj0 == "hello" &&
+    context.input.labeled_value.proj1 == 42
+};"#,
+        )
+        .unwrap();
+
+        let input = r#"{
+    "params": {
+        "tool": "tuple_tool",
+        "args": {
+            "coordinate": [1.0, 2.5],
+            "labeled_value": ["hello", 42]
+        }
+    }
+}"#;
+        let input_fname = temp_dir.path().join("input.json");
+        std::fs::write(&input_fname, input).unwrap();
+
+        let mut cmd = cargo_bin_cmd!("cedar-policy-mcp-schema-generator");
+        let cmd = cmd
+            .arg("authorize")
+            .arg("examples/stub.cedarschema")
+            .arg("examples/simple/tool_tuple.json")
+            .arg("--encode-numbers-as-decimal")
+            .arg("--request-json")
+            .arg(&request_fname)
+            .arg("--policies")
+            .arg(&policy_fname)
+            .arg("--entities")
+            .arg(&entities_fname)
+            .arg("--mcp-tool-input")
+            .arg(&input_fname);
+        cmd.unwrap().assert().success().stdout("ALLOW\n").stderr("");
+    }
+
+    #[test]
+    fn test_authorize_tuple_deny() {
+        let temp_dir = TempDir::new().unwrap();
+        let entities_fname = temp_dir.path().join("entities.json");
+        std::fs::write(&entities_fname, "[]").unwrap();
+
+        let request_json = r#"{
+    "principal": "MyMcpServer::User::\"test_user\"",
+    "resource": "MyMcpServer::McpServer::\"test_server\"",
+    "context": {
+        "session": {
+            "currentTimestamp": {
+                "__extn": {
+                    "fn": "datetime",
+                    "arg": "2025-12-16"
+                }
+            },
+            "ipaddr": {
+                "__extn": {
+                    "fn": "ip",
+                    "arg": "10.0.0.1"
+                }
+            }
+        }
+    }
+}"#;
+        let request_fname = temp_dir.path().join("request.json");
+        std::fs::write(&request_fname, request_json).unwrap();
+
+        let policy_fname = temp_dir.path().join("policies.cedar");
+        std::fs::write(
+            &policy_fname,
+            r#"permit(principal, action, resource) when {
+    context.input.coordinate.proj0 == decimal("99.0")
+};"#,
+        )
+        .unwrap();
+
+        let input = r#"{
+    "params": {
+        "tool": "tuple_tool",
+        "args": {
+            "coordinate": [1.0, 2.5]
+        }
+    }
+}"#;
+        let input_fname = temp_dir.path().join("input.json");
+        std::fs::write(&input_fname, input).unwrap();
+
+        let mut cmd = cargo_bin_cmd!("cedar-policy-mcp-schema-generator");
+        let cmd = cmd
+            .arg("authorize")
+            .arg("examples/stub.cedarschema")
+            .arg("examples/simple/tool_tuple.json")
+            .arg("--encode-numbers-as-decimal")
+            .arg("--request-json")
+            .arg(&request_fname)
             .arg("--policies")
             .arg(&policy_fname)
             .arg("--entities")

--- a/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
+++ b/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
@@ -502,25 +502,25 @@ mod cli {
         std::fs::write(&entities_fname, "[]").unwrap();
 
         let request_json = r#"{
-    "principal": "MyMcpServer::User::\"test_user\"",
-    "resource": "MyMcpServer::McpServer::\"test_server\"",
-    "context": {
-        "session": {
-            "currentTimestamp": {
-                "__extn": {
-                    "fn": "datetime",
-                    "arg": "2025-12-16"
-                }
-            },
-            "ipaddr": {
-                "__extn": {
-                    "fn": "ip",
-                    "arg": "10.0.0.1"
+            "principal": "MyMcpServer::User::\"test_user\"",
+            "resource": "MyMcpServer::McpServer::\"test_server\"",
+            "context": {
+                "session": {
+                    "currentTimestamp": {
+                        "__extn": {
+                            "fn": "datetime",
+                            "arg": "2025-12-16"
+                        }
+                    },
+                    "ipaddr": {
+                        "__extn": {
+                            "fn": "ip",
+                            "arg": "10.0.0.1"
+                        }
+                    }
                 }
             }
-        }
-    }
-}"#;
+        }"#;
         let request_fname = temp_dir.path().join("request.json");
         std::fs::write(&request_fname, request_json).unwrap();
 
@@ -528,22 +528,22 @@ mod cli {
         std::fs::write(
             &policy_fname,
             r#"permit(principal, action, resource) when {
-    context.input.coordinate.proj0 == decimal("1.0") &&
-    context.input.labeled_value.proj0 == "hello" &&
-    context.input.labeled_value.proj1 == 42
-};"#,
+                context.input.coordinate.proj0 == decimal("1.0") &&
+                context.input.labeled_value.proj0 == "hello" &&
+                context.input.labeled_value.proj1 == 42
+            };"#,
         )
         .unwrap();
 
         let input = r#"{
-    "params": {
-        "tool": "tuple_tool",
-        "args": {
-            "coordinate": [1.0, 2.5],
-            "labeled_value": ["hello", 42]
-        }
-    }
-}"#;
+            "params": {
+                "tool": "tuple_tool",
+                "args": {
+                    "coordinate": [1.0, 2.5],
+                    "labeled_value": ["hello", 42]
+                }
+            }
+        }"#;
         let input_fname = temp_dir.path().join("input.json");
         std::fs::write(&input_fname, input).unwrap();
 
@@ -571,25 +571,25 @@ mod cli {
         std::fs::write(&entities_fname, "[]").unwrap();
 
         let request_json = r#"{
-    "principal": "MyMcpServer::User::\"test_user\"",
-    "resource": "MyMcpServer::McpServer::\"test_server\"",
-    "context": {
-        "session": {
-            "currentTimestamp": {
-                "__extn": {
-                    "fn": "datetime",
-                    "arg": "2025-12-16"
-                }
-            },
-            "ipaddr": {
-                "__extn": {
-                    "fn": "ip",
-                    "arg": "10.0.0.1"
+            "principal": "MyMcpServer::User::\"test_user\"",
+            "resource": "MyMcpServer::McpServer::\"test_server\"",
+            "context": {
+                "session": {
+                    "currentTimestamp": {
+                        "__extn": {
+                            "fn": "datetime",
+                            "arg": "2025-12-16"
+                        }
+                    },
+                    "ipaddr": {
+                        "__extn": {
+                            "fn": "ip",
+                            "arg": "10.0.0.1"
+                        }
+                    }
                 }
             }
-        }
-    }
-}"#;
+        }"#;
         let request_fname = temp_dir.path().join("request.json");
         std::fs::write(&request_fname, request_json).unwrap();
 
@@ -597,19 +597,19 @@ mod cli {
         std::fs::write(
             &policy_fname,
             r#"permit(principal, action, resource) when {
-    context.input.coordinate.proj0 == decimal("99.0")
-};"#,
+                context.input.coordinate.proj0 == decimal("99.0")
+            };"#,
         )
         .unwrap();
 
         let input = r#"{
-    "params": {
-        "tool": "tuple_tool",
-        "args": {
-            "coordinate": [1.0, 2.5]
-        }
-    }
-}"#;
+            "params": {
+                "tool": "tuple_tool",
+                "args": {
+                    "coordinate": [1.0, 2.5]
+                }
+            }
+        }"#;
         let input_fname = temp_dir.path().join("input.json");
         std::fs::write(&input_fname, input).unwrap();
 

--- a/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
+++ b/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
@@ -86,6 +86,18 @@ mod lib {
             SchemaGeneratorConfig::default(),
         );
     }
+
+    #[test]
+    fn mixed_array_tool() {
+        // This test has prefixItems with a different type than items results in Set<Unknown>.
+        // You will not be able to write meanigful policies against those types.
+        // See https://github.com/cedar-policy/cedar-for-agents/issues/90 for an improvement.
+        run_integration_test(
+            "examples/simple/tool_mixed_array.json",
+            "examples/simple/tool_mixed_array.cedarschema",
+            SchemaGeneratorConfig::default(),
+        );
+    }
 }
 
 #[cfg(feature = "cli")]

--- a/rust/mcp-tools-sdk/CHANGELOG.md
+++ b/rust/mcp-tools-sdk/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 - Adds support for parsing and type validation of requests to (`Input` struct) and responses from (`Output` struct) MCP servers for the `tools/call` procedure.
+- Adds translation of tuple definitions in JSON Schema to `PropertyType::Tuple`.
 
 ### Changed:
 - Types arrays in JSON Schemas are translated to union of types instead of tuples.

--- a/rust/mcp-tools-sdk/src/deserializer.rs
+++ b/rust/mcp-tools-sdk/src/deserializer.rs
@@ -297,22 +297,7 @@ fn property_type_from_json_value(
                 }
             }
             Some("null") => Ok(PropertyType::Null),
-            Some("array") => {
-                ptype_obj.get("items").map(|items_json| {
-                    if items_json.is_object() {
-                        let items_type = property_type_from_json_value(items_json)?;
-                        Ok(PropertyType::Array { element_ty: Box::new(items_type) })
-                    } else if items_json.is_bool() || items_json.is_null() {
-                        Ok(PropertyType::Array { element_ty: Box::new(PropertyType::Unknown) })
-                    } else {
-                        Err(DeserializationError::unexpected_type(
-                            items_json,
-                            "Expected `items` attribute to be a JSON Schema (object) describing the type of array items.",
-                            ContentType::PropertyType
-                        ))
-                    }
-                }).unwrap_or_else(|| Ok(PropertyType::Array { element_ty: Box::new(PropertyType::Unknown) }))
-            }
+            Some("array") => property_type_from_json_array_def(ptype_obj),
             Some("object") => {
                 let required = required_from_json_value(ptype_obj.get("required"), ContentType::ToolParameters)?;
                 let properties = properties_from_json_value(ptype_obj.get("properties"), &required, ContentType::ToolParameters)?;
@@ -360,6 +345,63 @@ fn property_type_from_json_value(
         Ok(PropertyType::Ref { name: s.into() })
     } else {
         Ok(PropertyType::Unknown)
+    }
+}
+
+/// Generate a [`PropertyType`] when the JSON value's is like `{"type": "array", "items": {...} }`.
+/// Depending on whether there is `prefixItems` and `"items": "false"`, this results in a
+/// [`PropertyType::Tuple`] or a [`PropertyType::Array`].
+fn property_type_from_json_array_def(
+    ptype_obj: &LinkedHashMap<LocatedString, LocatedValue>,
+) -> Result<PropertyType, DeserializationError> {
+    let prefix_items = ptype_obj.get("prefixItems").and_then(|v| v.get_array());
+    let items_json = ptype_obj.get("items");
+
+    if let Some(prefix) = prefix_items {
+        let prefix_types: Vec<PropertyType> = prefix
+            .iter()
+            .map(property_type_from_json_value)
+            .collect::<Result<_, _>>()?;
+
+        match items_json {
+            // items: false means closed tuple
+            Some(items) if items.get_bool() == Some(false) => Ok(PropertyType::Tuple {
+                types: prefix_types,
+            }),
+            // items is a schema — check if all prefixItems match it, collapse to array
+            Some(items) if items.is_object() => {
+                let items_type = property_type_from_json_value(items)?;
+                if prefix_types.iter().all(|t| *t == items_type) {
+                    Ok(PropertyType::Array {
+                        element_ty: Box::new(items_type),
+                    })
+                } else {
+                    Ok(PropertyType::Array {
+                        element_ty: Box::new(PropertyType::Unknown),
+                    })
+                }
+            }
+            // items absent or items: true — open-ended, not a tuple
+            _ => Ok(PropertyType::Array {
+                element_ty: Box::new(PropertyType::Unknown),
+            }),
+        }
+    } else {
+        // No prefixItems — standard array handling
+        items_json.map(|items_json| {
+            if items_json.is_object() {
+                let items_type = property_type_from_json_value(items_json)?;
+                Ok(PropertyType::Array { element_ty: Box::new(items_type) })
+            } else if items_json.is_bool() || items_json.is_null() {
+                Ok(PropertyType::Array { element_ty: Box::new(PropertyType::Unknown) })
+            } else {
+                Err(DeserializationError::unexpected_type(
+                    items_json,
+                    "Expected `items` attribute to be a JSON Schema (object) describing the type of array items.",
+                    ContentType::PropertyType
+                ))
+            }
+        }).unwrap_or_else(|| Ok(PropertyType::Array { element_ty: Box::new(PropertyType::Unknown) }))
     }
 }
 
@@ -607,7 +649,6 @@ fn typedefs_are_well_founded(
 mod test {
     use super::*;
     use crate::parser::json_parser::JsonParser;
-    use cool_asserts::assert_matches;
 
     fn parse_property_type(json: &str) -> Result<PropertyType, DeserializationError> {
         let mut parser = JsonParser::new(json);
@@ -639,18 +680,130 @@ mod test {
     }
 
     #[test]
-    fn test_property_type_primitive_type_tuple() {
-        let result = parse_property_type(
-            r#"{"type": "array", "prefixItems": [{"type": "null"}, {"type": "string"}], "items": false}"#,
-        );
-        // TODO: We don't support tuples right now and this results in Array of unknowns instead
-        assert_matches!(
-            result,
-            Ok(PropertyType::Array {
-                element_ty
-            })
-            if *element_ty == PropertyType::Unknown
-        );
+    fn test_property_tuple() {
+        // Tuple cases (prefixItems with items: false)
+        let tuple_cases = vec![
+            (
+                // Empty tuple: empty prefixItems with items: false
+                r#"{"type": "array", "prefixItems": [], "items": false}"#,
+                PropertyType::Tuple { types: vec![] },
+            ),
+            (
+                // Singleton tuple with a string
+                r#"{"type": "array", "prefixItems": [{"type": "string"}], "items": false}"#,
+                PropertyType::Tuple {
+                    types: vec![PropertyType::String],
+                },
+            ),
+            (
+                // Tuple of integer and string
+                r#"{"type": "array", "prefixItems": [{"type": "integer"}, {"type": "string"}], "items": false}"#,
+                PropertyType::Tuple {
+                    types: vec![PropertyType::Integer, PropertyType::String],
+                },
+            ),
+            (
+                // Tuple with null element, a valid tuple
+                r#"{"type": "array", "prefixItems": [{"type": "null"}, {"type": "string"}], "items": false}"#,
+                PropertyType::Tuple {
+                    types: vec![PropertyType::Null, PropertyType::String],
+                },
+            ),
+            (
+                // Complex tuple type: tuple with nested object element
+                r#"{"type": "array", "prefixItems": [{"type": "string"}, {"type": "object", "properties": {"x": {"type": "integer"}}}], "items": false}"#,
+                PropertyType::Tuple {
+                    types: vec![
+                        PropertyType::String,
+                        PropertyType::Object {
+                            properties: vec![Property::new(
+                                "x".into(),
+                                false,
+                                PropertyType::Integer,
+                                None,
+                            )],
+                            additional_properties: None,
+                        },
+                    ],
+                },
+            ),
+            (
+                // Tuple with nested array element
+                r#"{"type": "array", "prefixItems": [{"type": "array", "items": {"type": "boolean"}}], "items": false}"#,
+                PropertyType::Tuple {
+                    types: vec![PropertyType::Array {
+                        element_ty: Box::new(PropertyType::Bool),
+                    }],
+                },
+            ),
+            (
+                // A tuple with all types being the same; still not an array when we know items:false
+                r#"{"type": "array", "prefixItems": [{"type": "integer"}, {"type": "integer"}, {"type": "integer"}], "items": false}"#,
+                PropertyType::Tuple {
+                    types: vec![
+                        PropertyType::Integer,
+                        PropertyType::Integer,
+                        PropertyType::Integer,
+                    ],
+                },
+            ),
+            (
+                // Tuple with enum element
+                r#"{"type": "array", "prefixItems": [{"type": "string", "enum": ["a", "b"]}, {"type": "number"}], "items": false}"#,
+                PropertyType::Tuple {
+                    types: vec![
+                        PropertyType::Enum {
+                            variants: vec!["a".into(), "b".into()],
+                        },
+                        PropertyType::Number,
+                    ],
+                },
+            ),
+        ];
+
+        // Non-tuple cases: test boundary bewteen tuples and arrays
+        let non_tuple_cases = vec![
+            (
+                // prefixItems without items: false — not a closed tuple, treat as array, but type unknown
+                r#"{"type": "array", "prefixItems": [{"type": "null"}, {"type": "string"}]}"#,
+                PropertyType::Array {
+                    element_ty: Box::new(PropertyType::Unknown),
+                },
+            ),
+            (
+                // prefixItems with items: true — open-ended, not a tuple, also unknown element type
+                r#"{"type": "array", "prefixItems": [{"type": "integer"}], "items": true}"#,
+                PropertyType::Array {
+                    element_ty: Box::new(PropertyType::Unknown),
+                },
+            ),
+            (
+                // No prefixItems, just items — plain array
+                r#"{"type": "array", "items": {"type": "string"}}"#,
+                PropertyType::Array {
+                    element_ty: Box::new(PropertyType::String),
+                },
+            ),
+            (
+                // prefixItems with items as a schema (additional items allowed with a type) — not a tuple
+                r#"{"type": "array", "prefixItems": [{"type": "integer"}], "items": {"type": "string"}}"#,
+                PropertyType::Array {
+                    element_ty: Box::new(PropertyType::Unknown),
+                },
+            ),
+            (
+                // prefixItems and items are the same type — should collapse to array of that type
+                r#"{"type": "array", "prefixItems": [{"type": "string"}, {"type": "string"}], "items": {"type": "string"}}"#,
+                PropertyType::Array {
+                    element_ty: Box::new(PropertyType::String),
+                },
+            ),
+        ];
+
+        for (json, expected) in tuple_cases.iter().chain(non_tuple_cases.iter()) {
+            let result = parse_property_type(json).unwrap();
+            assert_eq!(result, *expected, "Failed for input: {json}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes
Adds support for JSON Schema tuples.
A tuple defined by `{"type": "array", "prefixItems" : [{"type": "string"}, {"type": "integer"}], items: false}` is translated to a record `{ proj0: String, proj1: Long }`.

## Issue #, if available

#88

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A backwards-compatible change requiring a minor version bump to any crates in this repository (e.g., addition of a new API).
> Might be considered breaking, but on a minor version, and the previous schema generated for JSON tuples would not be usable (`Set<Unknown>`).

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).