### PR TITLE
Updated cedar-policy-mcp-schema-generator's dependencies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
  "ipnet",
  "iso8601",
  "linked-hash-map",
- "mcp-tools-sdk",
+ "mcp-tools-sdk 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "miette",
  "nonempty",
  "serde",
@@ -306,7 +306,7 @@ name = "cedar-policy-mcp-schema-generator-wasm"
 version = "0.1.0"
 dependencies = [
  "cedar-policy-mcp-schema-generator",
- "mcp-tools-sdk",
+ "mcp-tools-sdk 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "wasm-bindgen",
@@ -889,6 +889,23 @@ dependencies = [
  "nonempty",
  "smol_str",
  "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "mcp-tools-sdk"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8548034e087691c57da613e3611e1d6cd0e010dae513a30dc68c96f0a12aa4"
+dependencies = [
+ "chrono",
+ "ipnet",
+ "iso8601",
+ "itertools",
+ "linked-hash-map",
+ "miette",
+ "nonempty",
+ "smol_str",
  "thiserror",
 ]
 

--- a/rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator" }
-mcp-tools-sdk = { path = "../mcp-tools-sdk" }
+mcp-tools-sdk = { version = "0.3.0" }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/cedar-policy-mcp-schema-generator/Cargo.toml
+++ b/rust/cedar-policy-mcp-schema-generator/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-mcp-tools-sdk = { path = "../mcp-tools-sdk", version = "*" }
+mcp-tools-sdk = { version = "0.3.0" }
 cedar-policy-core = "=4.10.0"
 miette = "7.6.0"
 linked-hash-map = "0.5.6"


### PR DESCRIPTION
Update `mcp-tools-sdk = { version="0.3.0" }` in release branch of cedar-policy-mcp-schema-generator.

There is also a change in the cedar-policy-mcp-schema-generator-wasm/Cargo.toml to allow CI to pass (so that this crate doesn't have two mcp-policy-sdk versions in its tree). This does not touch the released crate, which is depended on by the *-wasm crate (which is also unreleased).