### PR TITLE
Adding entities deduplication where entities have basic typed attributes

### DIFF
--- a/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Adds `deduplicate_entity_types` option to consolidate equivalent enum entity types (same name and variants) into a single definition at the lowest common ancestor namespace.
+- Adds `deduplicate_entity_types` option to consolidate equivalent enum entity types (same name and variants) and leaf entity types (entities where all attributes are of base type, i.e. no nested entity) into a single definition at the lowest common ancestor namespace.
 
 ## [0.5.0] - 2026-05-12
 

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_enum_record_name_conflict.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_enum_record_name_conflict.cedarschema
@@ -1,4 +1,4 @@
-// There is a second enum of the same shape; it was de-duped because of a name conflict with
+// There is a second enum of the same shape; it wasn't de-duped because of a name conflict with
 // an entity "status"
 namespace MyMcpServer::tool_a::Input {
   entity status enum ["active", "inactive"];

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_enum_record_name_conflict.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_enum_record_name_conflict.cedarschema
@@ -1,7 +1,10 @@
+// There is a second enum of the same shape; it was de-duped because of a name conflict with
+// an entity "status"
 namespace MyMcpServer::tool_a::Input {
   entity status enum ["active", "inactive"];
 }
 
+// Same as the enum, this is not de-duped because of a name conflict with an enum
 namespace MyMcpServer::tool_b::Input {
   entity status = {
     code: Long,

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_enum_record_name_conflict.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_enum_record_name_conflict.cedarschema
@@ -1,0 +1,93 @@
+namespace MyMcpServer::tool_a::Input {
+  entity status enum ["active", "inactive"];
+}
+
+namespace MyMcpServer::tool_b::Input {
+  entity status = {
+    code: Long,
+    message: String
+  };
+}
+
+namespace MyMcpServer::tool_c::Input {
+  entity status enum ["active", "inactive"];
+}
+
+namespace MyMcpServer::tool_d::Input {
+  entity status = {
+    code: Long,
+    message: String
+  };
+}
+
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type tool_aInput = {
+    query: String,
+    status?: MyMcpServer::tool_a::Input::status
+  };
+
+  type tool_bInput = {
+    data: String,
+    status?: MyMcpServer::tool_b::Input::status
+  };
+
+  type tool_cInput = {
+    input: String,
+    status?: MyMcpServer::tool_c::Input::status
+  };
+
+  type tool_dInput = {
+    status?: MyMcpServer::tool_d::Input::status,
+    value: String
+  };
+
+  entity McpServer;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  action "call_tool";
+
+  action "tool_a" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_aInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_b" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_bInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_c" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_cInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_d" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_dInput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_enum_record_name_conflict.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_enum_record_name_conflict.json
@@ -1,0 +1,82 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "tool_a",
+        "description": "Tool A with 'status' as an enum",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [ "active", "inactive" ]
+              },
+              "query": { "type": "string" }
+            },
+            "required": [ "query" ]
+          }
+        }
+      },
+      {
+        "name": "tool_b",
+        "description": "Tool B with 'status' as a leaf record",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "object",
+                "properties": {
+                  "code": { "type": "integer" },
+                  "message": { "type": "string" }
+                },
+                "required": [ "code", "message" ]
+              },
+              "data": { "type": "string" }
+            },
+            "required": [ "data" ]
+          }
+        }
+      },
+      {
+        "name": "tool_c",
+        "description": "Tool C with same 'status' enum as tool_a",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [ "active", "inactive" ]
+              },
+              "input": { "type": "string" }
+            },
+            "required": [ "input" ]
+          }
+        }
+      },
+      {
+        "name": "tool_d",
+        "description": "Tool D with same 'status' record as tool_b",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "object",
+                "properties": {
+                  "code": { "type": "integer" },
+                  "message": { "type": "string" }
+                },
+                "required": [ "code", "message" ]
+              },
+              "value": { "type": "string" }
+            },
+            "required": [ "value" ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record.cedarschema
@@ -1,3 +1,7 @@
+// This. is an example where the MyMcpServer::metadata is being de-duplicated for tool_aInput and
+// tool_bInput. The input of tool_c is not a candidate for deduplicate with those two entity types
+// because it doesn't have the same signature.
+
 namespace MyMcpServer::tool_c::Input {
   entity metadata = {
     count: Long,

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record.cedarschema
@@ -1,4 +1,4 @@
-// This. is an example where the MyMcpServer::metadata is being de-duplicated for tool_aInput and
+// This is an example where the MyMcpServer::metadata is being de-duplicated for tool_aInput and
 // tool_bInput. The input of tool_c is not a candidate for deduplicate with those two entity types
 // because it doesn't have the same signature.
 

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record.cedarschema
@@ -1,0 +1,69 @@
+namespace MyMcpServer::tool_c::Input {
+  entity metadata = {
+    count: Long,
+    title: String
+  };
+}
+
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type tool_aInput = {
+    metadata?: MyMcpServer::metadata,
+    query: String
+  };
+
+  type tool_bInput = {
+    data: String,
+    metadata?: MyMcpServer::metadata
+  };
+
+  type tool_cInput = {
+    input: String,
+    metadata?: MyMcpServer::tool_c::Input::metadata
+  };
+
+  entity McpServer;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  entity metadata = {
+    author: String,
+    version?: Long
+  };
+
+  action "call_tool";
+
+  action "tool_a" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_aInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_b" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_bInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_c" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_cInput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record.json
@@ -1,0 +1,69 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "tool_a",
+        "description": "Tool A",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "author": { "type": "string" },
+                  "version": { "type": "integer" }
+                },
+                "required": [ "author" ]
+              },
+              "query": { "type": "string" }
+            },
+            "required": [ "query" ]
+          }
+        }
+      },
+      {
+        "name": "tool_b",
+        "description": "Tool B",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "author": { "type": "string" },
+                  "version": { "type": "integer" }
+                },
+                "required": [ "author" ]
+              },
+              "data": { "type": "string" }
+            },
+            "required": [ "data" ]
+          }
+        }
+      },
+      {
+        "name": "tool_c",
+        "description": "Tool C with different metadata",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "title": { "type": "string" },
+                  "count": { "type": "integer" }
+                },
+                "required": [ "title", "count" ]
+              },
+              "input": { "type": "string" }
+            },
+            "required": [ "input" ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_different_required.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_different_required.cedarschema
@@ -1,0 +1,57 @@
+namespace MyMcpServer::tool_a::Input {
+  entity metadata = {
+    author: String,
+    version?: Long
+  };
+}
+
+namespace MyMcpServer::tool_b::Input {
+  entity metadata = {
+    author: String,
+    version: Long
+  };
+}
+
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type tool_aInput = {
+    metadata?: MyMcpServer::tool_a::Input::metadata,
+    query: String
+  };
+
+  type tool_bInput = {
+    data: String,
+    metadata?: MyMcpServer::tool_b::Input::metadata
+  };
+
+  entity McpServer;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  action "call_tool";
+
+  action "tool_a" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_aInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_b" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_bInput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_different_required.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_different_required.cedarschema
@@ -1,3 +1,6 @@
+// In this example tool_a::Input::metadata and tool_b::Input::metadata have the same attributes,
+// but in tool_a's input the version is optional, so we cannot de-duplicate the types.
+
 namespace MyMcpServer::tool_a::Input {
   entity metadata = {
     author: String,

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_different_required.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_different_required.json
@@ -1,0 +1,48 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "tool_a",
+        "description": "Tool A: metadata with version optional",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "author": { "type": "string" },
+                  "version": { "type": "integer" }
+                },
+                "required": ["author"]
+              },
+              "query": { "type": "string" }
+            },
+            "required": ["query"]
+          }
+        }
+      },
+      {
+        "name": "tool_b",
+        "description": "Tool B: metadata with version required",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "author": { "type": "string" },
+                  "version": { "type": "integer" }
+                },
+                "required": ["author", "version"]
+              },
+              "data": { "type": "string" }
+            },
+            "required": ["data"]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_in_output.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_in_output.cedarschema
@@ -1,0 +1,59 @@
+// Two tools share the same leaf record "metadata" in their outputSchema.
+// With include_outputs + deduplicate_entity_types, the leaf record is deduplicated to the LCA.
+
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type tool_aInput = {
+    query: String
+  };
+
+  type tool_aOutput = {
+    metadata: MyMcpServer::metadata
+  };
+
+  type tool_bInput = {
+    id: String
+  };
+
+  type tool_bOutput = {
+    metadata: MyMcpServer::metadata
+  };
+
+  entity McpServer;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  entity metadata = {
+    author: String,
+    version?: Long
+  };
+
+  action "call_tool";
+
+  action "tool_a" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_aInput,
+      output?: tool_aOutput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_b" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_bInput,
+      output?: tool_bOutput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_in_output.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_in_output.json
@@ -1,0 +1,64 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "tool_a",
+        "description": "Tool A",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "query": { "type": "string" }
+            },
+            "required": ["query"]
+          }
+        },
+        "outputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "author": { "type": "string" },
+                  "version": { "type": "integer" }
+                },
+                "required": ["author"]
+              }
+            },
+            "required": ["metadata"]
+          }
+        }
+      },
+      {
+        "name": "tool_b",
+        "description": "Tool B",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            },
+            "required": ["id"]
+          }
+        },
+        "outputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "author": { "type": "string" },
+                  "version": { "type": "integer" }
+                },
+                "required": ["author"]
+              }
+            },
+            "required": ["metadata"]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_no_match.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_no_match.cedarschema
@@ -1,0 +1,78 @@
+namespace MyMcpServer::tool_a::Input {
+  entity config = {
+    host: String,
+    port: Long
+  };
+}
+
+namespace MyMcpServer::tool_b::Input {
+  entity config = {
+    timeout: Long,
+    url: String
+  };
+}
+
+namespace MyMcpServer::tool_c::Input {
+  entity config = {
+    host: Long,
+    port: String
+  };
+}
+
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type tool_aInput = {
+    config?: MyMcpServer::tool_a::Input::config,
+    query: String
+  };
+
+  type tool_bInput = {
+    config?: MyMcpServer::tool_b::Input::config,
+    data: String
+  };
+
+  type tool_cInput = {
+    config?: MyMcpServer::tool_c::Input::config,
+    input: String
+  };
+
+  entity McpServer;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  action "call_tool";
+
+  action "tool_a" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_aInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_b" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_bInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_c" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_cInput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_no_match.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_no_match.cedarschema
@@ -1,3 +1,6 @@
+// This is an example where the entities have the same name but different attributes; we obviously
+// shouldn't deduplicate them!
+
 namespace MyMcpServer::tool_a::Input {
   entity config = {
     host: String,

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_no_match.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_leaf_record_no_match.json
@@ -1,0 +1,69 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "tool_a",
+        "description": "Tool A: 'config' with fields (host: string, port: integer)",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "config": {
+                "type": "object",
+                "properties": {
+                  "host": { "type": "string" },
+                  "port": { "type": "integer" }
+                },
+                "required": [ "host", "port" ]
+              },
+              "query": { "type": "string" }
+            },
+            "required": [ "query" ]
+          }
+        }
+      },
+      {
+        "name": "tool_b",
+        "description": "Tool B: 'config' with different field names (url: string, timeout: integer)",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "config": {
+                "type": "object",
+                "properties": {
+                  "url": { "type": "string" },
+                  "timeout": { "type": "integer" }
+                },
+                "required": [ "url", "timeout" ]
+              },
+              "data": { "type": "string" }
+            },
+            "required": [ "data" ]
+          }
+        }
+      },
+      {
+        "name": "tool_c",
+        "description": "Tool C: 'config' with same field names as tool_a but different types (host: integer, port: string)",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "config": {
+                "type": "object",
+                "properties": {
+                  "host": { "type": "integer" },
+                  "port": { "type": "string" }
+                },
+                "required": [ "host", "port" ]
+              },
+              "input": { "type": "string" }
+            },
+            "required": [ "input" ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_mixed_enum_and_record.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_mixed_enum_and_record.cedarschema
@@ -1,0 +1,52 @@
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type tool_aInput = {
+    format?: MyMcpServer::format,
+    options?: MyMcpServer::options,
+    query: String
+  };
+
+  type tool_bInput = {
+    data: String,
+    format?: MyMcpServer::format,
+    options?: MyMcpServer::options
+  };
+
+  entity McpServer;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  entity format enum ["markdown", "text"];
+
+  entity options = {
+    timeout?: Long,
+    verbose: Bool
+  };
+
+  action "call_tool";
+
+  action "tool_a" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_aInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_b" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_bInput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_mixed_enum_and_record.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_mixed_enum_and_record.cedarschema
@@ -1,3 +1,6 @@
+// This example shows that we can de-duplicate both enums and normal entities with attributes.
+// The format enum and the options entities are the result of de-duplication.
+
 namespace MyMcpServer {
   type CommonContext = {
     currentTimestamp: datetime,

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_mixed_enum_and_record.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_mixed_enum_and_record.json
@@ -1,0 +1,56 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "tool_a",
+        "description": "Tool A",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [ "markdown", "text" ]
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "verbose": { "type": "boolean" },
+                  "timeout": { "type": "integer" }
+                },
+                "required": [ "verbose" ]
+              },
+              "query": { "type": "string" }
+            },
+            "required": [ "query" ]
+          }
+        }
+      },
+      {
+        "name": "tool_b",
+        "description": "Tool B",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [ "markdown", "text" ]
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "verbose": { "type": "boolean" },
+                  "timeout": { "type": "integer" }
+                },
+                "required": [ "verbose" ]
+              },
+              "data": { "type": "string" }
+            },
+            "required": [ "data" ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_nested_record_not_deduplicated.cedarschema
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_nested_record_not_deduplicated.cedarschema
@@ -1,0 +1,62 @@
+// Two tools have the same nested structure: a wrapping object "config" containing a leaf object
+// "settings". The innermost "settings" entity (all primitive fields) is deduplicated to the LCA,
+// but the wrapping "config" entity is NOT deduplicated because it is not a leaf record.
+
+namespace MyMcpServer::tool_a::Input {
+  entity config = {
+    settings: MyMcpServer::settings
+  };
+}
+
+namespace MyMcpServer::tool_b::Input {
+  entity config = {
+    settings: MyMcpServer::settings
+  };
+}
+
+namespace MyMcpServer {
+  type CommonContext = {
+    currentTimestamp: datetime,
+    ipaddr: ipaddr
+  };
+
+  type tool_aInput = {
+    config: MyMcpServer::tool_a::Input::config
+  };
+
+  type tool_bInput = {
+    config: MyMcpServer::tool_b::Input::config
+  };
+
+  entity McpServer;
+
+  entity User = {
+    id: String,
+    username: String
+  };
+
+  entity settings = {
+    timeout?: Long,
+    verbose: Bool
+  };
+
+  action "call_tool";
+
+  action "tool_a" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_aInput,
+      session: CommonContext
+    }
+  };
+
+  action "tool_b" in [Action::"call_tool"] appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: {
+      input: tool_bInput,
+      session: CommonContext
+    }
+  };
+}

--- a/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_nested_record_not_deduplicated.json
+++ b/rust/cedar-policy-mcp-schema-generator/examples/dedup/dedup_nested_record_not_deduplicated.json
@@ -1,0 +1,58 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "tool_a",
+        "description": "Tool A",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "config": {
+                "type": "object",
+                "properties": {
+                  "settings": {
+                    "type": "object",
+                    "properties": {
+                      "verbose": { "type": "boolean" },
+                      "timeout": { "type": "integer" }
+                    },
+                    "required": ["verbose"]
+                  }
+                },
+                "required": ["settings"]
+              }
+            },
+            "required": ["config"]
+          }
+        }
+      },
+      {
+        "name": "tool_b",
+        "description": "Tool B",
+        "inputSchema": {
+          "json": {
+            "type": "object",
+            "properties": {
+              "config": {
+                "type": "object",
+                "properties": {
+                  "settings": {
+                    "type": "object",
+                    "properties": {
+                      "verbose": { "type": "boolean" },
+                      "timeout": { "type": "integer" }
+                    },
+                    "required": ["verbose"]
+                  }
+                },
+                "required": ["settings"]
+              }
+            },
+            "required": ["config"]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/rust/cedar-policy-mcp-schema-generator/src/cli/args.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/cli/args.rs
@@ -88,7 +88,9 @@ pub(crate) struct ConfigOptions {
     pub(crate) encode_numbers_as_decimal: bool,
     /// Whether to deduplicate entity types with equivalent definitions across tools, placing
     /// the shared type in the lowest common ancestor namespace (default: false). Currently
-    /// applies to enum entity types matched by name and variant values.
+    /// applies to enum entity types matched by name and variant values, and entity types where
+    /// all attributes are base types (i.e. no nested records or enums) matched by name, attribute
+    /// names and types.
     #[arg(long, default_value_t = false)]
     pub(crate) deduplicate_entity_types: bool,
 }

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
@@ -21,6 +21,7 @@ use cedar_policy_core::ast::{
     Context, Eid, Entity, EntityType, EntityUID, InternalName, Name, Request, RestrictedExpr,
 };
 use cedar_policy_core::entities::Entities;
+use cedar_policy_core::parser::err::ParseErrors;
 use cedar_policy_core::validator::ValidatorSchema;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
@@ -459,25 +460,7 @@ impl RequestGenerator {
                 Ok((RestrictedExpr::val(euid), Entities::new()))
             }
             TypedValue::Enum(s) => {
-                let ty: EntityType = ty_name.parse()?;
-
-                // Check if this enum was deduplicated to a different namespace.
-                // Match by base_name AND verify the current namespace is a source,
-                // to avoid false matches with same-named enums that have different variants.
-                let qualified_ty = if let Some(ref resolved) = self.resolved_dedup {
-                    let dedup_info = resolved.iter().find(|(fp, info)| {
-                        fp.base_name().to_string() == ty_name
-                            && info.source_namespaces.contains(&namespace.cloned())
-                    });
-                    if let Some((_, info)) = dedup_info {
-                        ty.qualify_with(info.lca_namespace.as_ref())
-                    } else {
-                        ty.qualify_with(namespace)
-                    }
-                } else {
-                    ty.qualify_with(namespace)
-                };
-
+                let qualified_ty = self.resolved_ty(ty_name, namespace)?;
                 let eid = Eid::new(s.as_str());
                 let euid = EntityUID::from_components(qualified_ty, eid, None);
                 let euid = if self.config.flatten_namespaces {
@@ -568,15 +551,15 @@ impl RequestGenerator {
                 if tags.is_empty() && self.config.objects_as_records {
                     Ok((RestrictedExpr::record(pairs.into_iter())?, entities))
                 } else {
-                    let entity_ty: EntityType = ty_name.parse()?;
-                    let entity_ty = entity_ty.qualify_with(namespace);
+                    // Check if this object was deduplicated to a different namespace.
+                    let qualified_ty = self.resolved_ty(ty_name, namespace)?;
                     // Generate a unique EID for each object's entity representation
                     // This means that all entities are different from all other entities
                     // even if the entities are structurally equivalent.
                     // Perhaps we could generate EIDs in a way that result in equal EIDs for
                     // structurally equivalent entities.
                     let eid = Eid::new(Uuid::new_v4().to_smolstr());
-                    let euid = EntityUID::from_components(entity_ty, eid, None);
+                    let euid = EntityUID::from_components(qualified_ty, eid, None);
                     let euid = if self.config.flatten_namespaces {
                         flatten_name(euid)
                     } else {
@@ -602,6 +585,31 @@ impl RequestGenerator {
             TypedValue::Ref { name, val } => {
                 self.val_to_cedar(val, type_defs, type_defs.get(name), name.as_str())
             }
+        }
+    }
+
+    /// Checks if the type name was deduplicated in another namespace.
+    /// During request generation, the type name and the check on the namepace being
+    /// in the source namespaces is sufficient to resolve the deduplicated type.
+    fn resolved_ty(
+        &self,
+        ty_name: &str,
+        namespace: Option<&Name>,
+    ) -> Result<EntityType, ParseErrors> {
+        let ty: EntityType = ty_name.parse()?;
+
+        if let Some(ref resolved) = self.resolved_dedup {
+            let dedup_info = resolved.iter().find(|(fp, info)| {
+                fp.base_name().to_string() == ty_name
+                    && info.source_namespaces.contains(&namespace.cloned())
+            });
+            if let Some((_, info)) = dedup_info {
+                Ok(ty.qualify_with(info.lca_namespace.as_ref()))
+            } else {
+                Ok(ty.qualify_with(namespace))
+            }
+        } else {
+            Ok(ty.qualify_with(namespace))
         }
     }
 }
@@ -2625,6 +2633,118 @@ mod test {
                 let map = &**ikvs;
                 matches!(map.get("format").map(Value::value_kind), Some(ValueKind::Lit(Literal::EntityUID(eid))) if {
                     **eid == "Test::tool_c::Input::format::\"json\"".parse().expect("Failed to parse EID")
+                })
+            })
+        });
+    }
+
+    #[test]
+    fn test_generate_request_dedup_leaf_record_resolves_to_lca() {
+        // Two tools share a leaf record "opts" {verbose: bool, limit: int}.
+        // The request generator should resolve the entity type to the LCA namespace.
+        let tools_json = r#"{
+            "result": {
+                "tools": [
+                    {
+                        "name": "tool_a",
+                        "description": "Tool A",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "opts": {
+                                        "type": "object",
+                                        "properties": {
+                                            "verbose": { "type": "boolean" },
+                                            "limit": { "type": "integer" }
+                                        },
+                                        "required": ["verbose", "limit"]
+                                    }
+                                },
+                                "required": ["opts"]
+                            }
+                        }
+                    },
+                    {
+                        "name": "tool_b",
+                        "description": "Tool B",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "opts": {
+                                        "type": "object",
+                                        "properties": {
+                                            "verbose": { "type": "boolean" },
+                                            "limit": { "type": "integer" }
+                                        },
+                                        "required": ["verbose", "limit"]
+                                    }
+                                },
+                                "required": ["opts"]
+                            }
+                        }
+                    }
+                ]
+            }
+        }"#;
+
+        let config = SchemaGeneratorConfig::default().deduplicate_entity_types(true);
+        let mut schema_generator = get_schema_generator(config);
+        let description =
+            ServerDescription::from_json_str(tools_json).expect("Failed to parse tools JSON");
+        schema_generator
+            .add_actions_from_server_description(&description)
+            .expect("Failed to add server description");
+
+        let request_generator = schema_generator
+            .new_request_generator()
+            .expect("Failed to create request generator");
+
+        let input = Input::from_json_str(
+            r#"{
+            "params": {
+                "tool": "tool_a",
+                "args": { "opts": { "verbose": true, "limit": 10 } }
+            }
+        }"#,
+        )
+        .expect("Failed to parse input");
+
+        let principal = r#"Test::user::"""#.parse::<EntityUID>().unwrap();
+        let resource = r#"Test::resource::"""#.parse::<EntityUID>().unwrap();
+
+        let (request, entities) = request_generator
+            .generate_request(
+                principal,
+                resource,
+                Context::empty(),
+                Entities::new(),
+                &input,
+                None,
+            )
+            .expect("Failed to generate request");
+
+        // The entity should be typed to the LCA namespace (Test::opts)
+        let entity = entities
+            .iter()
+            .find(|e| e.uid().to_string().starts_with("Test::opts::\""));
+        assert!(
+            entity.is_some(),
+            "Expected entity with type Test::opts, got: {:?}",
+            entities
+                .iter()
+                .map(|e| e.uid().to_string())
+                .collect::<Vec<_>>()
+        );
+
+        // The context should reference the entity
+        assert_matches!(request.context(), Some(Context::Value(kvs)) if {
+            let map = &**kvs;
+            matches!(map.get("input").map(Value::value_kind), Some(ValueKind::Record(ikvs)) if {
+                let map = &**ikvs;
+                matches!(map.get("opts").map(Value::value_kind), Some(ValueKind::Lit(Literal::EntityUID(eid))) if {
+                    eid.to_string().starts_with("Test::opts::\"")
                 })
             })
         });

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -27,7 +27,9 @@ use cedar_policy_core::validator::{
     },
     RawName,
 };
-use mcp_tools_sdk::description::{Parameters, PropertyType, ServerDescription, ToolDescription};
+use mcp_tools_sdk::description::{
+    Parameters, Property, PropertyType, ServerDescription, ToolDescription,
+};
 
 use nonempty::NonEmpty;
 
@@ -192,13 +194,17 @@ fn is_leaf_record(p: &PropertyType) -> bool {
 /// Designed as an enum to support future extension to other entity type kinds.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum EntityTypeFingerprint {
-    /// Fingerprint for enum entity types: matched by name + ordered variant values.
+    /// Fingerprint for enum entity types.
+    /// The order of variants in enums matters, i.e. ['foo', 'bar'] and
+    /// ['bar', 'foo'] are two different entity types.
+    /// Enum fingerprints are matched by name + variant values (in original order).
     Enum {
         base_name: UnreservedId,
         variants: Vec<SmolStr>,
     },
     /// Fingerprint for leaf record entity types: objects whose properties are all primitive.
-    /// Matched by name + sorted list of (property_name, type, required).
+    /// The order of attributes in objects does not matter.
+    /// Record fingerprints are matched by name + sorted list of (property_name, type, required).
     LeafRecord {
         base_name: UnreservedId,
         /// Sorted by property name for deterministic comparison.
@@ -211,6 +217,24 @@ impl EntityTypeFingerprint {
         match self {
             Self::Enum { base_name, .. } | Self::LeafRecord { base_name, .. } => base_name,
         }
+    }
+
+    pub(crate) fn new_leaf_record(
+        base_name: UnreservedId,
+        props: &[Property],
+    ) -> EntityTypeFingerprint {
+        let mut fields: Vec<(SmolStr, PropertyType, bool)> = props
+            .iter()
+            .map(|prop| {
+                (
+                    prop.name().to_smolstr(),
+                    prop.property_type().clone(),
+                    prop.is_required(),
+                )
+            })
+            .collect();
+        fields.sort_by(|a, b| a.0.cmp(&b.0));
+        EntityTypeFingerprint::LeafRecord { base_name, fields }
     }
 }
 
@@ -696,19 +720,8 @@ impl SchemaGenerator {
 
                     if is_leaf_record(property_type) {
                         if let Ok(base_name) = name.parse::<UnreservedId>() {
-                            let mut fields: Vec<(SmolStr, PropertyType, bool)> = properties
-                                .iter()
-                                .map(|prop| {
-                                    (
-                                        prop.name().to_smolstr(),
-                                        prop.property_type().clone(),
-                                        prop.is_required(),
-                                    )
-                                })
-                                .collect();
-                            fields.sort_by(|a, b| a.0.cmp(&b.0));
                             let fingerprint =
-                                EntityTypeFingerprint::LeafRecord { base_name, fields };
+                                EntityTypeFingerprint::new_leaf_record(base_name, properties);
                             dedup_map.record(fingerprint, namespace.clone());
                         }
                     }
@@ -1622,21 +1635,8 @@ impl SchemaGenerator {
             } => {
                 // Check if this is a leaf record and it was deduplicated (placed in LCA namespace during Pass 1)
                 if !self.config.objects_as_records && is_leaf_record(property_type) {
-                    let mut fields: Vec<(SmolStr, PropertyType, bool)> = properties
-                        .iter()
-                        .map(|prop| {
-                            (
-                                prop.name().to_smolstr(),
-                                prop.property_type().clone(),
-                                prop.is_required(),
-                            )
-                        })
-                        .collect();
-                    fields.sort_by(|a, b| a.0.cmp(&b.0));
-                    let fingerprint = EntityTypeFingerprint::LeafRecord {
-                        base_name: ty_name.clone(),
-                        fields,
-                    };
+                    let fingerprint =
+                        EntityTypeFingerprint::new_leaf_record(ty_name.clone(), properties);
                     if let Some(lca_ns) = self.get_dedup_namespace(&fingerprint) {
                         let name = RawName::new_from_unreserved(ty_name, None);
                         let name = RawName::from_name(name.qualify_with_name(lca_ns.as_ref()));

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -169,6 +169,22 @@ fn is_primitive(pt: &PropertyType) -> bool {
     )
 }
 
+// Returns `true` if the record is a "leaf" record, i.e. all its properties are of
+// primitive type and it doesn't have any `additionalProperties`
+fn is_leaf_record(p: &PropertyType) -> bool {
+    match p {
+        PropertyType::Object {
+            properties,
+            additional_properties,
+        } => {
+            additional_properties.is_none()
+                && !properties.is_empty()
+                && properties.iter().all(|p| is_primitive(p.property_type()))
+        }
+        _ => false,
+    }
+}
+
 /// A fingerprint that uniquely identifies an entity type's definition.
 /// Two entity types are considered equivalent (and thus deduplication candidates)
 /// if and only if they produce the same fingerprint.
@@ -678,12 +694,7 @@ impl SchemaGenerator {
                         );
                     }
 
-                    // Record leaf record fingerprint if all properties are primitive
-                    // and there are no additional_properties (tags).
-                    if additional_properties.is_none()
-                        && !properties.is_empty()
-                        && properties.iter().all(|p| is_primitive(p.property_type()))
-                    {
+                    if is_leaf_record(property_type) {
                         if let Ok(base_name) = name.parse::<UnreservedId>() {
                             let mut fields: Vec<(SmolStr, PropertyType, bool)> = properties
                                 .iter()
@@ -1609,12 +1620,8 @@ impl SchemaGenerator {
                 properties,
                 additional_properties,
             } => {
-                // Check if this leaf record was deduplicated (placed in LCA namespace during Pass 1)
-                if !self.config.objects_as_records
-                    && additional_properties.is_none()
-                    && !properties.is_empty()
-                    && properties.iter().all(|p| is_primitive(p.property_type()))
-                {
+                // Check if this is a leaf record and it was deduplicated (placed in LCA namespace during Pass 1)
+                if !self.config.objects_as_records && is_leaf_record(property_type) {
                     let mut fields: Vec<(SmolStr, PropertyType, bool)> = properties
                         .iter()
                         .map(|prop| {

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -151,6 +151,24 @@ impl Default for SchemaGeneratorConfig {
     }
 }
 
+/// Returns `true` if the `PropertyType` is a primitive (leaf) type.
+fn is_primitive(pt: &PropertyType) -> bool {
+    matches!(
+        pt,
+        PropertyType::Bool
+            | PropertyType::Integer
+            | PropertyType::Float
+            | PropertyType::Number
+            | PropertyType::String
+            | PropertyType::Decimal
+            | PropertyType::Datetime
+            | PropertyType::Duration
+            | PropertyType::IpAddr
+            | PropertyType::Null
+            | PropertyType::Unknown
+    )
+}
+
 /// A fingerprint that uniquely identifies an entity type's definition.
 /// Two entity types are considered equivalent (and thus deduplication candidates)
 /// if and only if they produce the same fingerprint.
@@ -163,12 +181,19 @@ pub(crate) enum EntityTypeFingerprint {
         base_name: UnreservedId,
         variants: Vec<SmolStr>,
     },
+    /// Fingerprint for leaf record entity types: objects whose properties are all primitive.
+    /// Matched by name + sorted list of (property_name, type, required).
+    LeafRecord {
+        base_name: UnreservedId,
+        /// Sorted by property name for deterministic comparison.
+        fields: Vec<(SmolStr, PropertyType, bool)>,
+    },
 }
 
 impl EntityTypeFingerprint {
     pub(crate) fn base_name(&self) -> &UnreservedId {
         match self {
-            Self::Enum { base_name, .. } => base_name,
+            Self::Enum { base_name, .. } | Self::LeafRecord { base_name, .. } => base_name,
         }
     }
 }
@@ -482,6 +507,87 @@ impl SchemaGenerator {
                 }
                 _ => false,
             },
+            EntityTypeFingerprint::LeafRecord {
+                base_name: _,
+                fields,
+            } => match &entity.kind {
+                EntityTypeKind::Standard(std_entity) => {
+                    Self::record_matches_fields(&std_entity.shape.0, fields)
+                }
+                _ => false,
+            },
+        }
+    }
+
+    /// Check if a record type matches the expected leaf record fields.
+    fn record_matches_fields(ty: &Type<RawName>, fields: &[(SmolStr, PropertyType, bool)]) -> bool {
+        let Type::Type {
+            ty: TypeVariant::Record(record),
+            ..
+        } = ty
+        else {
+            return false;
+        };
+        if record.attributes.len() != fields.len() {
+            return false;
+        }
+        let mut existing: Vec<(&SmolStr, &TypeOfAttribute<RawName>)> =
+            record.attributes.iter().collect();
+        existing.sort_by_key(|(name, _)| *name);
+        existing
+            .iter()
+            .zip(fields.iter())
+            .all(|((name, attr), (f_name, f_type, f_required))| {
+                *name == f_name
+                    && attr.required == *f_required
+                    && Self::type_matches_primitive(&attr.ty, f_type)
+            })
+    }
+
+    /// Check if a Cedar type corresponds to the given primitive property type.
+    fn type_matches_primitive(ty: &Type<RawName>, prim: &PropertyType) -> bool {
+        let Type::Type { ty: variant, .. } = ty else {
+            return false;
+        };
+        match (variant, prim) {
+            (TypeVariant::EntityOrCommon { type_name }, prim) => {
+                let expected = match prim {
+                    PropertyType::Bool => &identifiers::BOOL_TYPE,
+                    PropertyType::Integer => &identifiers::LONG_TYPE,
+                    PropertyType::String => &identifiers::STRING_TYPE,
+                    PropertyType::Decimal => &identifiers::DECIMAL_TYPE,
+                    PropertyType::Datetime => &identifiers::DATETIME_TYPE,
+                    PropertyType::Duration => &identifiers::DURATION_TYPE,
+                    PropertyType::IpAddr => &identifiers::IPADDR_TYPE,
+                    _ => return false,
+                };
+                type_name == &**expected
+            }
+            (TypeVariant::Entity { name }, PropertyType::Float) => {
+                name == &RawName::from_name(
+                    RawName::new_from_unreserved(identifiers::FLOAT_TYPE.clone(), None)
+                        .qualify_with_name(None),
+                )
+            }
+            (TypeVariant::Entity { name }, PropertyType::Number) => {
+                name == &RawName::from_name(
+                    RawName::new_from_unreserved(identifiers::NUMBER_TYPE.clone(), None)
+                        .qualify_with_name(None),
+                )
+            }
+            (TypeVariant::Entity { name }, PropertyType::Null) => {
+                name == &RawName::from_name(
+                    RawName::new_from_unreserved(identifiers::NULL_TYPE.clone(), None)
+                        .qualify_with_name(None),
+                )
+            }
+            (TypeVariant::Entity { name }, PropertyType::Unknown) => {
+                name == &RawName::from_name(
+                    RawName::new_from_unreserved(identifiers::UNKNOWN_TYPE.clone(), None)
+                        .qualify_with_name(None),
+                )
+            }
+            _ => false,
         }
     }
 
@@ -570,6 +676,30 @@ impl SchemaGenerator {
                             &child_ns,
                             dedup_map,
                         );
+                    }
+
+                    // Record leaf record fingerprint if all properties are primitive
+                    // and there are no additional_properties (tags).
+                    if additional_properties.is_none()
+                        && !properties.is_empty()
+                        && properties.iter().all(|p| is_primitive(p.property_type()))
+                    {
+                        if let Ok(base_name) = name.parse::<UnreservedId>() {
+                            let mut fields: Vec<(SmolStr, PropertyType, bool)> = properties
+                                .iter()
+                                .map(|prop| {
+                                    (
+                                        prop.name().to_smolstr(),
+                                        prop.property_type().clone(),
+                                        prop.is_required(),
+                                    )
+                                })
+                                .collect();
+                            fields.sort_by(|a, b| a.0.cmp(&b.0));
+                            let fingerprint =
+                                EntityTypeFingerprint::LeafRecord { base_name, fields };
+                            dedup_map.record(fingerprint, namespace.clone());
+                        }
                     }
                 }
             }
@@ -734,7 +864,12 @@ impl SchemaGenerator {
             }
         }
 
-        let resolved = dedup_map.resolve_duplicates();
+        let mut resolved = dedup_map.resolve_duplicates();
+
+        // LeafRecord dedup only applies when objects are encoded as entity types
+        if self.config.objects_as_records {
+            resolved.retain(|fp, _| !matches!(fp, EntityTypeFingerprint::LeafRecord { .. }));
+        }
 
         // Determine which fingerprints to skip:
         // - Same base_name targeting the same LCA (different variants conflict)
@@ -801,6 +936,46 @@ impl SchemaGenerator {
                         let choices = NonEmpty::from_slice(variants).unwrap();
                         let ty = EntityType {
                             kind: EntityTypeKind::Enum { choices },
+                            annotations: Annotations::new(),
+                            loc: None,
+                        };
+                        self.add_entitytype(lca_ns, ty, base_name.clone(), true)?;
+                    }
+                    EntityTypeFingerprint::LeafRecord { base_name, fields } => {
+                        let empty_common_types = BTreeMap::new();
+                        let attributes = fields
+                            .iter()
+                            .map(|(name, prop_type, required)| {
+                                let ty_name: UnreservedId =
+                                    name.parse().map_err(SchemaGeneratorError::from)?;
+                                let ty = self.cedar_type_from_property_type(
+                                    lca_ns,
+                                    ty_name,
+                                    prop_type,
+                                    &empty_common_types,
+                                )?;
+                                Ok((
+                                    name.clone(),
+                                    TypeOfAttribute {
+                                        ty,
+                                        annotations: Annotations::new(),
+                                        required: *required,
+                                    },
+                                ))
+                            })
+                            .collect::<Result<_, SchemaGeneratorError>>()?;
+                        let ty = EntityType {
+                            kind: EntityTypeKind::Standard(StandardEntityType {
+                                member_of_types: Vec::new(),
+                                shape: AttributesOrContext(Type::Type {
+                                    ty: TypeVariant::Record(RecordType {
+                                        attributes,
+                                        additional_attributes: false,
+                                    }),
+                                    loc: None,
+                                }),
+                                tags: None,
+                            }),
                             annotations: Annotations::new(),
                             loc: None,
                         };
@@ -1434,6 +1609,39 @@ impl SchemaGenerator {
                 properties,
                 additional_properties,
             } => {
+                // Check if this leaf record was deduplicated (placed in LCA namespace during Pass 1)
+                if !self.config.objects_as_records
+                    && additional_properties.is_none()
+                    && !properties.is_empty()
+                    && properties.iter().all(|p| is_primitive(p.property_type()))
+                {
+                    let mut fields: Vec<(SmolStr, PropertyType, bool)> = properties
+                        .iter()
+                        .map(|prop| {
+                            (
+                                prop.name().to_smolstr(),
+                                prop.property_type().clone(),
+                                prop.is_required(),
+                            )
+                        })
+                        .collect();
+                    fields.sort_by(|a, b| a.0.cmp(&b.0));
+                    let fingerprint = EntityTypeFingerprint::LeafRecord {
+                        base_name: ty_name.clone(),
+                        fields,
+                    };
+                    if let Some(lca_ns) = self.get_dedup_namespace(&fingerprint) {
+                        let name = RawName::new_from_unreserved(ty_name, None);
+                        let name = RawName::from_name(name.qualify_with_name(lca_ns.as_ref()));
+                        return Ok(Type::Type {
+                            ty: TypeVariant::Entity {
+                                name: self.flatten_rawname(name),
+                            },
+                            loc: None,
+                        });
+                    }
+                }
+
                 let ns: Name = ty_name.clone().into();
                 let ns = Some(ns.qualify_with_name(namespace.as_ref()));
                 self.add_namespace(ns.clone());
@@ -2088,7 +2296,7 @@ mod test {
         let schema = r#"namespace Test {
 }
 
-namespace Test2 {       
+namespace Test2 {
 }"#;
 
         let schema_stub = Fragment::from_cedarschema_str(schema, Extensions::all_available())
@@ -2452,6 +2660,396 @@ namespace Test2 {
         assert_eq!(
             str_output, display_output,
             "get_schema_as_str and Display should produce identical output"
+        );
+    }
+
+    #[test]
+    fn test_is_primitive() {
+        assert!(is_primitive(&PropertyType::Bool));
+        assert!(is_primitive(&PropertyType::Integer));
+        assert!(is_primitive(&PropertyType::Float));
+        assert!(is_primitive(&PropertyType::Number));
+        assert!(is_primitive(&PropertyType::String));
+        assert!(is_primitive(&PropertyType::Decimal));
+        assert!(is_primitive(&PropertyType::Datetime));
+        assert!(is_primitive(&PropertyType::Duration));
+        assert!(is_primitive(&PropertyType::IpAddr));
+        assert!(is_primitive(&PropertyType::Null));
+        assert!(is_primitive(&PropertyType::Unknown));
+
+        assert!(!is_primitive(&PropertyType::Enum {
+            variants: vec!["a".into()]
+        }));
+        assert!(!is_primitive(&PropertyType::Array {
+            element_ty: Box::new(PropertyType::String)
+        }));
+        assert!(!is_primitive(&PropertyType::Object {
+            properties: vec![],
+            additional_properties: None
+        }));
+        assert!(!is_primitive(&PropertyType::Ref { name: "Foo".into() }));
+        assert!(!is_primitive(&PropertyType::Tuple {
+            types: vec![PropertyType::String]
+        }));
+        assert!(!is_primitive(&PropertyType::Union {
+            types: vec![PropertyType::String]
+        }));
+    }
+
+    #[test]
+    fn test_leaf_record_fingerprint_equality() {
+        let fp1 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![
+                ("host".into(), PropertyType::String, true),
+                ("port".into(), PropertyType::Integer, true),
+            ],
+        };
+        let fp2 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![
+                ("host".into(), PropertyType::String, true),
+                ("port".into(), PropertyType::Integer, true),
+            ],
+        };
+        assert_eq!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_leaf_record_fingerprint_different_name() {
+        let fp1 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![("host".into(), PropertyType::String, true)],
+        };
+        let fp2 = EntityTypeFingerprint::LeafRecord {
+            base_name: "settings".parse().unwrap(),
+            fields: vec![("host".into(), PropertyType::String, true)],
+        };
+        assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_leaf_record_fingerprint_different_field_names() {
+        let fp1 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![("host".into(), PropertyType::String, true)],
+        };
+        let fp2 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![("url".into(), PropertyType::String, true)],
+        };
+        assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_leaf_record_fingerprint_different_field_types() {
+        let fp1 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![("port".into(), PropertyType::Integer, true)],
+        };
+        let fp2 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![("port".into(), PropertyType::String, true)],
+        };
+        assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_leaf_record_fingerprint_different_required() {
+        let fp1 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![("host".into(), PropertyType::String, true)],
+        };
+        let fp2 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![("host".into(), PropertyType::String, false)],
+        };
+        assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_leaf_record_fingerprint_not_equal_to_enum() {
+        let fp_record = EntityTypeFingerprint::LeafRecord {
+            base_name: "status".parse().unwrap(),
+            fields: vec![("code".into(), PropertyType::Integer, true)],
+        };
+        let fp_enum = EntityTypeFingerprint::Enum {
+            base_name: "status".parse().unwrap(),
+            variants: vec!["active".into()],
+        };
+        assert_ne!(fp_record, fp_enum);
+    }
+
+    #[test]
+    fn test_leaf_record_fingerprint_hash_consistency() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let fp1 = EntityTypeFingerprint::LeafRecord {
+            base_name: "config".parse().unwrap(),
+            fields: vec![
+                ("host".into(), PropertyType::String, true),
+                ("port".into(), PropertyType::Integer, false),
+            ],
+        };
+        let fp2 = fp1.clone();
+
+        let mut h1 = DefaultHasher::new();
+        let mut h2 = DefaultHasher::new();
+        fp1.hash(&mut h1);
+        fp2.hash(&mut h2);
+        assert_eq!(h1.finish(), h2.finish());
+    }
+
+    #[test]
+    fn test_dedup_leaf_record_schema_generation() {
+        let schema_stub = test_schema_stub();
+        let config = SchemaGeneratorConfig::default().deduplicate_entity_types(true);
+
+        let tools_json = r#"{
+            "result": {
+                "tools": [
+                    {
+                        "name": "tool_a",
+                        "description": "Tool A",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "opts": {
+                                        "type": "object",
+                                        "properties": {
+                                            "verbose": { "type": "boolean" },
+                                            "limit": { "type": "integer" }
+                                        },
+                                        "required": ["verbose"]
+                                    }
+                                },
+                                "required": ["opts"]
+                            }
+                        }
+                    },
+                    {
+                        "name": "tool_b",
+                        "description": "Tool B",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "opts": {
+                                        "type": "object",
+                                        "properties": {
+                                            "verbose": { "type": "boolean" },
+                                            "limit": { "type": "integer" }
+                                        },
+                                        "required": ["verbose"]
+                                    }
+                                },
+                                "required": ["opts"]
+                            }
+                        }
+                    }
+                ]
+            }
+        }"#;
+
+        let description =
+            ServerDescription::from_json_str(tools_json).expect("Failed to parse tools JSON");
+        let mut generator = SchemaGenerator::new_with_config(schema_stub, config)
+            .expect("Failed to create schema generator");
+        generator
+            .add_actions_from_server_description(&description)
+            .expect("Failed to add server description");
+
+        let schema = generator.get_schema();
+        let root_ns = Some("Test".parse::<Name>().unwrap());
+        let root_nsdef = schema.0.get(&root_ns).expect("Expected namespace Test");
+
+        // The deduplicated entity type should be in the root namespace
+        assert!(
+            root_nsdef
+                .entity_types
+                .contains_key(&"opts".parse().unwrap()),
+            "Expected deduplicated 'opts' entity type in root namespace"
+        );
+
+        // Tool-local namespaces should NOT have their own 'opts'
+        let tool_a_input_ns: Option<Name> = Some("Test::tool_a::Input".parse().unwrap());
+        let tool_a_nsdef = schema.0.get(&tool_a_input_ns);
+        assert!(
+            tool_a_nsdef.is_none()
+                || !tool_a_nsdef
+                    .unwrap()
+                    .entity_types
+                    .contains_key(&"opts".parse().unwrap()),
+            "tool_a::Input should not have local 'opts'"
+        );
+    }
+
+    #[test]
+    fn test_dedup_leaf_record_not_triggered_for_non_leaf() {
+        // An object with a nested object property should NOT be fingerprinted as a leaf record
+        let schema_stub = test_schema_stub();
+        let config = SchemaGeneratorConfig::default().deduplicate_entity_types(true);
+
+        let tools_json = r#"{
+            "result": {
+                "tools": [
+                    {
+                        "name": "tool_a",
+                        "description": "Tool A",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "nested": {
+                                        "type": "object",
+                                        "properties": {
+                                            "inner": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "val": { "type": "string" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "required": ["nested"]
+                            }
+                        }
+                    },
+                    {
+                        "name": "tool_b",
+                        "description": "Tool B",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "nested": {
+                                        "type": "object",
+                                        "properties": {
+                                            "inner": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "val": { "type": "string" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "required": ["nested"]
+                            }
+                        }
+                    }
+                ]
+            }
+        }"#;
+
+        let description =
+            ServerDescription::from_json_str(tools_json).expect("Failed to parse tools JSON");
+        let mut generator = SchemaGenerator::new_with_config(schema_stub, config)
+            .expect("Failed to create schema generator");
+        generator
+            .add_actions_from_server_description(&description)
+            .expect("Failed to add server description");
+
+        let schema = generator.get_schema();
+        let root_ns = Some("Test".parse::<Name>().unwrap());
+        let root_nsdef = schema.0.get(&root_ns).expect("Expected namespace Test");
+
+        // Non-leaf objects should NOT be deduplicated to root
+        assert!(
+            !root_nsdef
+                .entity_types
+                .contains_key(&"nested".parse().unwrap()),
+            "Non-leaf 'nested' should not be deduplicated to root namespace"
+        );
+    }
+
+    #[test]
+    fn test_dedup_leaf_record_skipped_with_objects_as_records() {
+        // With objects_as_records, leaf records become common types, not entity types.
+        // Dedup should not apply.
+        let schema_stub = test_schema_stub();
+        let config = SchemaGeneratorConfig::default()
+            .deduplicate_entity_types(true)
+            .objects_as_records(true);
+
+        let tools_json = r#"{
+            "result": {
+                "tools": [
+                    {
+                        "name": "tool_a",
+                        "description": "Tool A",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "meta": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": { "type": "string" }
+                                        },
+                                        "required": ["name"]
+                                    }
+                                },
+                                "required": ["meta"]
+                            }
+                        }
+                    },
+                    {
+                        "name": "tool_b",
+                        "description": "Tool B",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "meta": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": { "type": "string" }
+                                        },
+                                        "required": ["name"]
+                                    }
+                                },
+                                "required": ["meta"]
+                            }
+                        }
+                    }
+                ]
+            }
+        }"#;
+
+        let description =
+            ServerDescription::from_json_str(tools_json).expect("Failed to parse tools JSON");
+        let mut generator = SchemaGenerator::new_with_config(schema_stub, config)
+            .expect("Failed to create schema generator");
+        generator
+            .add_actions_from_server_description(&description)
+            .expect("Failed to add server description");
+
+        let schema = generator.get_schema();
+        let root_ns = Some("Test".parse::<Name>().unwrap());
+        let root_nsdef = schema.0.get(&root_ns).expect("Expected namespace Test");
+
+        // Should NOT have a deduplicated entity type in root
+        assert!(
+            !root_nsdef
+                .entity_types
+                .contains_key(&"meta".parse().unwrap()),
+            "'meta' should not be deduplicated as entity type when objects_as_records is true"
+        );
+        // Should have common types in tool-local namespaces instead
+        let tool_a_input_ns: Option<Name> = Some("Test::tool_a::Input".parse().unwrap());
+        let tool_a_nsdef = schema
+            .0
+            .get(&tool_a_input_ns)
+            .expect("Expected tool_a::Input namespace");
+        assert!(
+            tool_a_nsdef
+                .common_types
+                .contains_key(&CommonTypeId::new("meta".parse().unwrap()).unwrap()),
+            "tool_a::Input should have local 'meta' common type"
         );
     }
 }

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -130,7 +130,6 @@ impl SchemaGeneratorConfig {
     ///
     /// Currently supports enum entity types (matched by name + variant values)
     /// and structural entity types where all attributes are of base type.
-    /// Future versions may extend to structural entity types.
     pub fn deduplicate_entity_types(self, val: bool) -> Self {
         Self {
             deduplicate_entity_types: val,

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -128,7 +128,8 @@ impl SchemaGeneratorConfig {
     /// equivalent definitions across multiple tools will be consolidated into
     /// a single entity type placed in the lowest common ancestor namespace.
     ///
-    /// Currently supports enum entity types (matched by name + variant values).
+    /// Currently supports enum entity types (matched by name + variant values)
+    /// and structural entity types where all attributes are of base type.
     /// Future versions may extend to structural entity types.
     pub fn deduplicate_entity_types(self, val: bool) -> Self {
         Self {

--- a/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
+++ b/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
@@ -39,17 +39,25 @@ mod lib {
             .add_actions_from_server_description(&description)
             .expect("Failed to add tool actions to schema generator");
 
-        // Read expected schema file
+        // The expected files have comments in them to make it nicer to read the examples,
+        // but they need to be stripped before comparison.
         let mut schema_file =
             std::fs::File::open(schema_fname).expect("Failed to read expected output file");
-        let mut expected_schema = String::new();
+        let mut raw_schema = String::new();
         let _ = schema_file
-            .read_to_string(&mut expected_schema)
+            .read_to_string(&mut raw_schema)
             .expect("Failed to read expected schema file");
+        let expected_schema: String = raw_schema
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string()
+            + "\n";
 
         let actual_schema = generator
             .get_schema()
-            .clone()
             .to_cedarschema()
             .expect("Failed to resolve generated schema");
         assert!(

--- a/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
+++ b/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
@@ -1235,6 +1235,33 @@ namespace MyMcpServer {
             SchemaGeneratorConfig::default().deduplicate_entity_types(true),
         );
     }
+
+    #[test]
+    fn dedup_nested_record_not_deduplicated() {
+        // Two tools have the same nested structure: a wrapping object "config" containing
+        // a leaf object "settings". The innermost "settings" entity (all primitive fields)
+        // should be deduplicated to the LCA, but the wrapping "config" entity should NOT
+        // be deduplicated because it is not a leaf record (it references another entity type).
+        run_integration_test(
+            "examples/dedup/dedup_nested_record_not_deduplicated.json",
+            "examples/dedup/dedup_nested_record_not_deduplicated.cedarschema",
+            SchemaGeneratorConfig::default().deduplicate_entity_types(true),
+        );
+    }
+
+    #[test]
+    fn dedup_leaf_record_in_output() {
+        // Two tools share the same leaf record "metadata" in their outputSchema.
+        // With include_outputs + deduplicate_entity_types, the leaf record should be
+        // deduplicated to the LCA namespace.
+        run_integration_test(
+            "examples/dedup/dedup_leaf_record_in_output.json",
+            "examples/dedup/dedup_leaf_record_in_output.cedarschema",
+            SchemaGeneratorConfig::default()
+                .include_outputs(true)
+                .deduplicate_entity_types(true),
+        );
+    }
 }
 
 #[cfg(feature = "cli")]

--- a/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
+++ b/rust/cedar-policy-mcp-schema-generator/tests/integration.rs
@@ -159,6 +159,63 @@ mod lib {
     }
 
     #[test]
+    fn dedup_leaf_record_different_required() {
+        // Two tools have "metadata" with same field names and types, but different
+        // required status (version? vs version). They should NOT be deduplicated.
+        run_integration_test(
+            "examples/dedup/dedup_leaf_record_different_required.json",
+            "examples/dedup/dedup_leaf_record_different_required.cedarschema",
+            SchemaGeneratorConfig::default().deduplicate_entity_types(true),
+        );
+    }
+
+    #[test]
+    fn dedup_leaf_record() {
+        // tool_a and tool_b share the same "metadata" leaf record (author: String, version?: Long).
+        // tool_c has a different "metadata" (title: String, count: Long).
+        // The shared one should be deduplicated to the LCA namespace; tool_c keeps its own.
+        run_integration_test(
+            "examples/dedup/dedup_leaf_record.json",
+            "examples/dedup/dedup_leaf_record.cedarschema",
+            SchemaGeneratorConfig::default().deduplicate_entity_types(true),
+        );
+    }
+
+    #[test]
+    fn dedup_mixed_enum_and_record() {
+        // Both an enum ("format") and a leaf record ("options") are shared across two tools.
+        // Both should be deduplicated to the LCA namespace.
+        run_integration_test(
+            "examples/dedup/dedup_mixed_enum_and_record.json",
+            "examples/dedup/dedup_mixed_enum_and_record.cedarschema",
+            SchemaGeneratorConfig::default().deduplicate_entity_types(true),
+        );
+    }
+
+    #[test]
+    fn dedup_enum_record_name_conflict() {
+        // An enum and a leaf record both named "status" target the same LCA.
+        // Both should be skipped (no dedup) because of the name collision.
+        run_integration_test(
+            "examples/dedup/dedup_enum_record_name_conflict.json",
+            "examples/dedup/dedup_enum_record_name_conflict.cedarschema",
+            SchemaGeneratorConfig::default().deduplicate_entity_types(true),
+        );
+    }
+
+    #[test]
+    fn dedup_leaf_record_no_match() {
+        // Three tools have "config" with: different field names (tool_a vs tool_b),
+        // same field names but different types (tool_a vs tool_c).
+        // None should be deduplicated.
+        run_integration_test(
+            "examples/dedup/dedup_leaf_record_no_match.json",
+            "examples/dedup/dedup_leaf_record_no_match.cedarschema",
+            SchemaGeneratorConfig::default().deduplicate_entity_types(true),
+        );
+    }
+
+    #[test]
     fn dedup_entity_types() {
         run_integration_test(
             "examples/dedup/dedup_tools.json",
@@ -1703,6 +1760,282 @@ mod cli {
             .arg("examples/stub.cedarschema")
             .arg("examples/simple/tool_tuple.json")
             .arg("--encode-numbers-as-decimal")
+            .arg("--request-json")
+            .arg(&request_fname)
+            .arg("--policies")
+            .arg(&policy_fname)
+            .arg("--entities")
+            .arg(&entities_fname)
+            .arg("--mcp-tool-input")
+            .arg(&input_fname);
+        cmd.unwrap().assert().success().stdout("DENY\n").stderr("");
+    }
+
+    #[test]
+    fn test_authorize_dedup_leaf_record_allow() {
+        // Two tools share a leaf record "metadata" {author: String, version?: Long}.
+        // With dedup, the entity type is placed in the LCA namespace.
+        // Policy checks the entity's attributes via has/access on the entity.
+        let temp_dir = TempDir::new().unwrap();
+        let entities_fname = temp_dir.path().join("entities.json");
+        std::fs::write(&entities_fname, "[]").unwrap();
+
+        let request_json = r#"{
+    "principal": "MyMcpServer::User::\"test_user\"",
+    "resource": "MyMcpServer::McpServer::\"test_server\"",
+    "context": {
+        "session": {
+            "currentTimestamp": {
+                "__extn": {
+                    "fn": "datetime",
+                    "arg": "2025-12-16"
+                }
+            },
+            "ipaddr": {
+                "__extn": {
+                    "fn": "ip",
+                    "arg": "10.0.0.1"
+                }
+            }
+        }
+    }
+}"#;
+        let request_fname = temp_dir.path().join("request.json");
+        std::fs::write(&request_fname, request_json).unwrap();
+
+        let policy_fname = temp_dir.path().join("policies.cedar");
+        std::fs::write(
+            &policy_fname,
+            r#"permit(principal, action, resource) when {
+    context.input.query == "hello"
+};"#,
+        )
+        .unwrap();
+
+        let input = r#"{
+    "params": {
+        "tool": "tool_a",
+        "args": {
+            "metadata": { "author": "alice", "version": 2 },
+            "query": "hello"
+        }
+    }
+}"#;
+        let input_fname = temp_dir.path().join("input.json");
+        std::fs::write(&input_fname, input).unwrap();
+
+        let mut cmd = cargo_bin_cmd!("cedar-policy-mcp-schema-generator");
+        let cmd = cmd
+            .arg("authorize")
+            .arg("examples/stub.cedarschema")
+            .arg("examples/dedup/dedup_leaf_record.json")
+            .arg("--deduplicate-entity-types")
+            .arg("--request-json")
+            .arg(&request_fname)
+            .arg("--policies")
+            .arg(&policy_fname)
+            .arg("--entities")
+            .arg(&entities_fname)
+            .arg("--mcp-tool-input")
+            .arg(&input_fname);
+        cmd.unwrap().assert().success().stdout("ALLOW\n").stderr("");
+    }
+
+    #[test]
+    fn test_authorize_dedup_leaf_record_deny() {
+        let temp_dir = TempDir::new().unwrap();
+        let entities_fname = temp_dir.path().join("entities.json");
+        std::fs::write(&entities_fname, "[]").unwrap();
+
+        let request_json = r#"{
+    "principal": "MyMcpServer::User::\"test_user\"",
+    "resource": "MyMcpServer::McpServer::\"test_server\"",
+    "context": {
+        "session": {
+            "currentTimestamp": {
+                "__extn": {
+                    "fn": "datetime",
+                    "arg": "2025-12-16"
+                }
+            },
+            "ipaddr": {
+                "__extn": {
+                    "fn": "ip",
+                    "arg": "10.0.0.1"
+                }
+            }
+        }
+    }
+}"#;
+        let request_fname = temp_dir.path().join("request.json");
+        std::fs::write(&request_fname, request_json).unwrap();
+
+        let policy_fname = temp_dir.path().join("policies.cedar");
+        std::fs::write(
+            &policy_fname,
+            r#"permit(principal, action, resource) when {
+    context.input.query == "world"
+};"#,
+        )
+        .unwrap();
+
+        let input = r#"{
+    "params": {
+        "tool": "tool_a",
+        "args": {
+            "metadata": { "author": "alice", "version": 2 },
+            "query": "hello"
+        }
+    }
+}"#;
+        let input_fname = temp_dir.path().join("input.json");
+        std::fs::write(&input_fname, input).unwrap();
+
+        let mut cmd = cargo_bin_cmd!("cedar-policy-mcp-schema-generator");
+        let cmd = cmd
+            .arg("authorize")
+            .arg("examples/stub.cedarschema")
+            .arg("examples/dedup/dedup_leaf_record.json")
+            .arg("--deduplicate-entity-types")
+            .arg("--request-json")
+            .arg(&request_fname)
+            .arg("--policies")
+            .arg(&policy_fname)
+            .arg("--entities")
+            .arg(&entities_fname)
+            .arg("--mcp-tool-input")
+            .arg(&input_fname);
+        cmd.unwrap().assert().success().stdout("DENY\n").stderr("");
+    }
+
+    #[test]
+    fn test_authorize_dedup_mixed_enum_and_record_allow() {
+        // Tests authorization with both a deduplicated enum and a deduplicated leaf record.
+        let temp_dir = TempDir::new().unwrap();
+        let entities_fname = temp_dir.path().join("entities.json");
+        std::fs::write(&entities_fname, "[]").unwrap();
+
+        let request_json = r#"{
+    "principal": "MyMcpServer::User::\"test_user\"",
+    "resource": "MyMcpServer::McpServer::\"test_server\"",
+    "context": {
+        "session": {
+            "currentTimestamp": {
+                "__extn": {
+                    "fn": "datetime",
+                    "arg": "2025-12-16"
+                }
+            },
+            "ipaddr": {
+                "__extn": {
+                    "fn": "ip",
+                    "arg": "10.0.0.1"
+                }
+            }
+        }
+    }
+}"#;
+        let request_fname = temp_dir.path().join("request.json");
+        std::fs::write(&request_fname, request_json).unwrap();
+
+        let policy_fname = temp_dir.path().join("policies.cedar");
+        std::fs::write(
+            &policy_fname,
+            r#"permit(principal, action, resource) when {
+    context.input has format &&
+    context.input.format == MyMcpServer::format::"markdown"
+};"#,
+        )
+        .unwrap();
+
+        let input = r#"{
+    "params": {
+        "tool": "tool_a",
+        "args": {
+            "format": "markdown",
+            "options": { "verbose": true, "timeout": 30 },
+            "query": "test"
+        }
+    }
+}"#;
+        let input_fname = temp_dir.path().join("input.json");
+        std::fs::write(&input_fname, input).unwrap();
+
+        let mut cmd = cargo_bin_cmd!("cedar-policy-mcp-schema-generator");
+        let cmd = cmd
+            .arg("authorize")
+            .arg("examples/stub.cedarschema")
+            .arg("examples/dedup/dedup_mixed_enum_and_record.json")
+            .arg("--deduplicate-entity-types")
+            .arg("--request-json")
+            .arg(&request_fname)
+            .arg("--policies")
+            .arg(&policy_fname)
+            .arg("--entities")
+            .arg(&entities_fname)
+            .arg("--mcp-tool-input")
+            .arg(&input_fname);
+        cmd.unwrap().assert().success().stdout("ALLOW\n").stderr("");
+    }
+
+    #[test]
+    fn test_authorize_dedup_mixed_enum_and_record_deny() {
+        let temp_dir = TempDir::new().unwrap();
+        let entities_fname = temp_dir.path().join("entities.json");
+        std::fs::write(&entities_fname, "[]").unwrap();
+
+        let request_json = r#"{
+    "principal": "MyMcpServer::User::\"test_user\"",
+    "resource": "MyMcpServer::McpServer::\"test_server\"",
+    "context": {
+        "session": {
+            "currentTimestamp": {
+                "__extn": {
+                    "fn": "datetime",
+                    "arg": "2025-12-16"
+                }
+            },
+            "ipaddr": {
+                "__extn": {
+                    "fn": "ip",
+                    "arg": "10.0.0.1"
+                }
+            }
+        }
+    }
+}"#;
+        let request_fname = temp_dir.path().join("request.json");
+        std::fs::write(&request_fname, request_json).unwrap();
+
+        let policy_fname = temp_dir.path().join("policies.cedar");
+        std::fs::write(
+            &policy_fname,
+            r#"permit(principal, action, resource) when {
+    context.input has format &&
+    context.input.format == MyMcpServer::format::"text"
+};"#,
+        )
+        .unwrap();
+
+        let input = r#"{
+    "params": {
+        "tool": "tool_b",
+        "args": {
+            "format": "markdown",
+            "options": { "verbose": false },
+            "data": "payload"
+        }
+    }
+}"#;
+        let input_fname = temp_dir.path().join("input.json");
+        std::fs::write(&input_fname, input).unwrap();
+
+        let mut cmd = cargo_bin_cmd!("cedar-policy-mcp-schema-generator");
+        let cmd = cmd
+            .arg("authorize")
+            .arg("examples/stub.cedarschema")
+            .arg("examples/dedup/dedup_mixed_enum_and_record.json")
+            .arg("--deduplicate-entity-types")
             .arg("--request-json")
             .arg(&request_fname)
             .arg("--policies")

--- a/rust/mcp-tools-sdk/src/description.rs
+++ b/rust/mcp-tools-sdk/src/description.rs
@@ -25,7 +25,7 @@ use super::parser;
 use super::validation::{validate_input, validate_output};
 
 /// The type a `Property` can take
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PropertyType {
     Unknown,
     Bool,
@@ -61,7 +61,7 @@ pub enum PropertyType {
 
 /// Representation of an input (or output) `Property`
 /// I.e., an attribute of an JSON Object Schema type
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Property {
     pub(crate) name: SmolStr,
     pub(crate) description: Option<String>,


### PR DESCRIPTION
## Description of changes

This extends the deduplication functionality to entities where all attributes are base types.

## Checklist for requesting a review
The change in this PR is (choose one, and delete the other options):
- [x] A backwards-compatible change requiring a minor version bump to any crates in this repository (e.g., addition of a new API). -> cedar-polic-mcp-schema-generator 0.6.0 and mcp-tools-sdk 0.3.1

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).