### PR TITLE
consistent formatting of numbers as decimals

### DIFF
--- a/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Adds `deduplicate_entity_types` option to consolidate equivalent enum entity types (same name and variants) and leaf entity types (entities where all attributes are of base type, i.e. no nested entity) into a single definition at the lowest common ancestor namespace.
+-
+### Changed
+- Translation of JSON numbers to Cedar decimals does not special case integers (represents both `10` and `10.0` as `10.0000`)
 
 ## [0.5.0] - 2026-05-12
 

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
@@ -389,9 +389,8 @@ impl RequestGenerator {
             }
             TypedValue::Number(n) => {
                 if self.config.numbers_as_decimal {
-                    let val = match (n.to_f64(), n.to_i64()) {
-                        (_, Some(i)) => format!("{}.0", i),
-                        (Some(f), _) => format!("{:.4}", f),
+                    let val = match n.to_f64() {
+                        Some(f) => format!("{:.4}", f),
                         _ => {
                             return Err(RequestGeneratorError::MalformedDecimalNumber(
                                 n.as_str().into(),
@@ -1577,10 +1576,45 @@ mod test {
                     RestrictedExpr::from((**dval).clone()) == RestrictedExpr::from_str("decimal(\"-0.0100\")").unwrap()
                 ) &&
                 matches!(map.get("pseudo_int").map(Value::value_kind), Some(ValueKind::ExtensionValue(dval)) if
-                    RestrictedExpr::from((**dval).clone()) == RestrictedExpr::from_str("decimal(\"10.0\")").unwrap()
+                    RestrictedExpr::from((**dval).clone()) == RestrictedExpr::from_str("decimal(\"10.0000\")").unwrap()
                 )
             })
         });
+    }
+
+    #[test]
+    fn test_number_as_decimal_consistent_for_integer_and_float_representations() {
+        // Regression: "10" and "10.0" should produce the same decimal literal
+        let config = SchemaGeneratorConfig::default().encode_numbers_as_decimal(true);
+        let schema_gen = get_schema_generator(config);
+        let request_gen = schema_gen
+            .new_request_generator()
+            .expect("Failed to construct request generator");
+        let type_defs = TypeDefsInfo::new();
+        let namespace: Option<cedar_policy_core::ast::Name> = Some("Test".parse().unwrap());
+
+        let cases = vec![
+            ("10", "decimal(\"10.0000\")"),
+            ("10.0", "decimal(\"10.0000\")"),
+            ("5", "decimal(\"5.0000\")"),
+            ("5.0", "decimal(\"5.0000\")"),
+            ("-3", "decimal(\"-3.0000\")"),
+            ("-3.0", "decimal(\"-3.0000\")"),
+        ];
+
+        for (input, expected) in cases {
+            let num = str_to_number(input);
+            let val = TypedValue::Number(num);
+            let (expr, _) = request_gen
+                .val_to_cedar(&val, &type_defs, namespace.as_ref(), "test_type")
+                .unwrap_or_else(|_| panic!("Failed to convert Number({}) to Cedar", input));
+            let expected_expr = RestrictedExpr::from_str(expected).unwrap();
+            assert_eq!(
+                expr, expected_expr,
+                "Number(\"{}\") produced {} but expected {}",
+                input, expr, expected_expr
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

This changes how numbers are parsed from JSON and printed in Cedar when using the decimals option so that the representation of `10` and `10.0` is consistent.


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A backwards-compatible change requiring a minor version bump to any crates in this repository (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).