### PR TITLE
decode JSON escape sequences

### DIFF
--- a/rust/mcp-tools-sdk/CHANGELOG.md
+++ b/rust/mcp-tools-sdk/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `PropertyType::Decimal` validation properly rejects inputs such as `1-0.2` and `-01.2` (`-` in the numbers and negative number with leading zeroes).
+- JSON parser now decodes JSON escape sequences in JSON strings.
+
 
 ## [0.3.0] - 2026-05-12
 

--- a/rust/mcp-tools-sdk/src/data.rs
+++ b/rust/mcp-tools-sdk/src/data.rs
@@ -967,4 +967,27 @@ mod test {
             Err(DeserializationError::UnexpectedType(..))
         )
     }
+
+    #[test]
+    fn test_input_string_escape_sequences_decoded() {
+        let input = r#"{
+            "method": "tools/call",
+            "params": {
+                "tool": "my_tool",
+                "args": {
+                    "path": "\/etc\/passwd",
+                    "message": "line1\nline2",
+                    "unicode": "\u0048ello"
+                }
+            }
+        }"#;
+        let parsed = Input::from_json_str(input).expect("Failed to parse input");
+        let args: Vec<_> = parsed.get_args().collect();
+        let path = &args.iter().find(|(k, _)| *k == "path").unwrap().1;
+        let message = &args.iter().find(|(k, _)| *k == "message").unwrap().1;
+        let unicode = &args.iter().find(|(k, _)| *k == "unicode").unwrap().1;
+        assert_eq!(path.get_str(), Some("/etc/passwd"));
+        assert_eq!(message.get_str(), Some("line1\nline2"));
+        assert_eq!(unicode.get_str(), Some("Hello"));
+    }
 }

--- a/rust/mcp-tools-sdk/src/parser/err.rs
+++ b/rust/mcp-tools-sdk/src/parser/err.rs
@@ -35,6 +35,11 @@ pub enum ParseError {
     #[error("Duplicate key found")]
     #[diagnostic(transparent)]
     DuplicateKey(DuplicateFound),
+
+    /// The parser encountered an invalid Unicode escape sequence (e.g., malformed surrogate pair)
+    #[error("Invalid Unicode escape sequence in string literal")]
+    #[diagnostic(transparent)]
+    InvalidUnicodeEscape(LocationFound),
 }
 
 impl ParseError {
@@ -58,6 +63,16 @@ impl ParseError {
             second,
             msg: "All keys should be unique.".to_string(),
             code: "parse::duplicate_key".to_string(),
+        })
+    }
+
+    /// Create a new `ParseError` representing an invalid Unicode escape sequence
+    pub(crate) fn invalid_unicode_escape(loc: Loc, msg: &str) -> Self {
+        Self::InvalidUnicodeEscape(LocationFound {
+            src: loc,
+            label: "Found".to_string(),
+            msg: msg.to_string(),
+            code: "parse::invalid_unicode_escape".to_string(),
         })
     }
 }

--- a/rust/mcp-tools-sdk/src/parser/json_parser.rs
+++ b/rust/mcp-tools-sdk/src/parser/json_parser.rs
@@ -43,7 +43,7 @@ impl JsonParser {
             match token.kind() {
                 TokenKind::String => {
                     maybe_empty = false;
-                    let key = LocatedString::new(token.into_loc());
+                    let key = LocatedString::new(token.into_loc())?;
                     let token = self.tokenizer.get_token()?;
                     if matches!(token.kind(), TokenKind::Colon) {
                         let value = self.get_value()?;
@@ -117,7 +117,7 @@ impl JsonParser {
                 TokenKind::Null => LocatedValue::new_null(token.into_loc()),
                 TokenKind::Bool(b) => LocatedValue::new_bool(b, token.into_loc()),
                 TokenKind::Number => LocatedValue::new_number(token.into_loc()),
-                TokenKind::String => LocatedValue::new_string(token.into_loc()),
+                TokenKind::String => LocatedValue::new_string(token.into_loc())?,
                 TokenKind::ArrayStart => self.get_array(token.as_loc())?,
                 TokenKind::ObjectStart => self.get_object(token.as_loc())?,
                 TokenKind::ArrayEnd if maybe_empty => {
@@ -169,7 +169,7 @@ impl JsonParser {
             TokenKind::Null => Ok(LocatedValue::new_null(token.into_loc())),
             TokenKind::Bool(b) => Ok(LocatedValue::new_bool(b, token.into_loc())),
             TokenKind::Number => Ok(LocatedValue::new_number(token.into_loc())),
-            TokenKind::String => Ok(LocatedValue::new_string(token.into_loc())),
+            TokenKind::String => LocatedValue::new_string(token.into_loc()),
             TokenKind::ArrayStart => self.get_array(token.as_loc()),
             TokenKind::ObjectStart => self.get_object(token.as_loc()),
             _ => Err(ParseError::unexpected_token(
@@ -305,7 +305,7 @@ mod tests {
         let value = parser
             .get_value()
             .expect("Failed to parse `    \"   \\t\\n\\r\\t  \"        `");
-        assert_matches!(value.get_str(), Some("   \\t\\n\\r\\t  "));
+        assert_matches!(value.get_str(), Some("   \t\n\r\t  "));
         assert_matches!(
             parser.get_value(),
             Err(ParseError::TokenizeError(TokenizeError::UnexpectedEof(..)))
@@ -316,11 +316,68 @@ mod tests {
     fn parse_unicode_escape_seq_string_literal() {
         let mut parser = JsonParser::new("\"\\u0912\"");
         let value = parser.get_value().expect("Failed to parse `\"\\u0912\"`");
-        assert_matches!(value.get_str(), Some("\\u0912"));
+        assert_matches!(value.get_str(), Some("\u{0912}"));
         assert_matches!(
             parser.get_value(),
             Err(ParseError::TokenizeError(TokenizeError::UnexpectedEof(..)))
         );
+    }
+
+    #[test]
+    fn parse_all_escape_sequences() {
+        let mut parser =
+            JsonParser::new(r#""quote:\" backslash:\\ slash:\/ bs:\b ff:\f nl:\n cr:\r tab:\t""#);
+        let value = parser
+            .get_value()
+            .expect("Failed to parse escape sequences");
+        assert_eq!(
+            value.get_str().unwrap(),
+            "quote:\" backslash:\\ slash:/ bs:\u{0008} ff:\u{000C} nl:\n cr:\r tab:\t"
+        );
+    }
+
+    #[test]
+    fn parse_unicode_surrogate_pair() {
+        // U+1F600 (😀) encoded as surrogate pair \uD83D\uDE00
+        let mut parser = JsonParser::new("\"\\uD83D\\uDE00\"");
+        let value = parser.get_value().expect("Failed to parse surrogate pair");
+        assert_eq!(value.get_str().unwrap(), "😀");
+    }
+
+    #[test]
+    fn parse_lone_high_surrogate_rejected() {
+        // High surrogate not followed by a low surrogate
+        let mut parser = JsonParser::new("\"\\uD83D\\u0041\"");
+        assert_matches!(
+            parser.get_value(),
+            Err(ParseError::InvalidUnicodeEscape(..))
+        );
+    }
+
+    #[test]
+    fn parse_lone_low_surrogate_rejected() {
+        // Low surrogate without preceding high surrogate
+        let mut parser = JsonParser::new("\"\\uDE00\"");
+        assert_matches!(
+            parser.get_value(),
+            Err(ParseError::InvalidUnicodeEscape(..))
+        );
+    }
+
+    #[test]
+    fn parse_object_key_with_escapes() {
+        let mut parser = JsonParser::new(r#"{"key\nname": "value"}"#);
+        let value = parser.get_value().expect("Failed to parse object");
+        let obj = value.get_object().expect("Expected object");
+        // The key should be decoded: "key\nname" (with actual newline)
+        assert!(obj.get("key\nname").is_some());
+    }
+
+    #[test]
+    fn parse_string_no_escapes_unchanged() {
+        let mut parser = JsonParser::new("\"hello world\"");
+        let value = parser.get_value().expect("Failed to parse");
+        assert_eq!(value.get_str().unwrap(), "hello world");
     }
 
     #[test]

--- a/rust/mcp-tools-sdk/src/parser/json_value.rs
+++ b/rust/mcp-tools-sdk/src/parser/json_value.rs
@@ -20,7 +20,92 @@ use smol_str::SmolStr;
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
 
+use super::err::ParseError;
 use super::loc::Loc;
+
+/// Decode JSON escape sequences from a raw string slice (content between quotes).
+/// Returns `Ok(None)` if the string contains no escape sequences (allowing zero-copy).
+/// Returns `Err` if the string contains an invalid Unicode escape (e.g., malformed surrogate pair).
+fn decode_json_escapes(raw: &str, loc: &Loc) -> Result<Option<String>, ParseError> {
+    if !raw.contains('\\') {
+        return Ok(None);
+    }
+    let mut decoded = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            decoded.push(c);
+            continue;
+        }
+        // JSON Spec (RFC 8259, Section 7) defines escape sequences that must be decoded
+        // https://www.rfc-editor.org/rfc/rfc8259#section-7
+        match chars.next() {
+            Some('"') => decoded.push('"'),
+            Some('\\') => decoded.push('\\'),
+            Some('/') => decoded.push('/'),
+            Some('b') => decoded.push('\u{0008}'),
+            Some('f') => decoded.push('\u{000C}'),
+            Some('n') => decoded.push('\n'),
+            Some('r') => decoded.push('\r'),
+            Some('t') => decoded.push('\t'),
+            Some('u') => {
+                let hex: String = chars.by_ref().take(4).collect();
+                // Tokenizer guarantees hex should be a valid u16 (max FFFF)
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "Tokenizer validates exactly 4 hex digits after \\u"
+                )]
+                let code_point = u16::from_str_radix(&hex, 16).unwrap();
+                // Handle UTF-16 surrogate pairs
+                if (0xD800..=0xDBFF).contains(&code_point) {
+                    // High surrogate — expect \uXXXX low surrogate
+                    let has_low = chars.next() == Some('\\') && chars.next() == Some('u');
+                    if !has_low {
+                        return Err(ParseError::invalid_unicode_escape(
+                            loc.clone(),
+                            "High surrogate not followed by \\uXXXX low surrogate",
+                        ));
+                    }
+                    let hex2: String = chars.by_ref().take(4).collect();
+                    #[expect(
+                        clippy::unwrap_used,
+                        reason = "Tokenizer validates exactly 4 hex digits after \\u"
+                    )]
+                    let low = u16::from_str_radix(&hex2, 16).unwrap();
+                    match char::decode_utf16([code_point, low]).next() {
+                        Some(Ok(ch)) => decoded.push(ch),
+                        _ => {
+                            return Err(ParseError::invalid_unicode_escape(
+                                loc.clone(),
+                                "Invalid UTF-16 surrogate pair",
+                            ));
+                        }
+                    }
+                } else if (0xDC00..=0xDFFF).contains(&code_point) {
+                    // Lone low surrogate
+                    return Err(ParseError::invalid_unicode_escape(
+                        loc.clone(),
+                        "Unexpected low surrogate without preceding high surrogate",
+                    ));
+                } else if let Some(ch) = char::from_u32(u32::from(code_point)) {
+                    decoded.push(ch);
+                } else {
+                    return Err(ParseError::invalid_unicode_escape(
+                        loc.clone(),
+                        "Invalid Unicode code point",
+                    ));
+                }
+            }
+            // The tokenizer already validated escape sequences, so this is unreachable
+            Some(other) => {
+                decoded.push('\\');
+                decoded.push(other);
+            }
+            None => decoded.push('\\'),
+        }
+    }
+    Ok(Some(decoded))
+}
 
 // The kind of a Located (JSON) Value
 #[derive(Debug, Clone)]
@@ -28,7 +113,7 @@ pub(crate) enum ValueKind {
     Null,
     Bool(bool),
     Number,
-    String,
+    String(SmolStr),
     Array(Vec<LocatedValue>),
     Object(LinkedHashMap<LocatedString, LocatedValue>),
 }
@@ -37,6 +122,7 @@ pub(crate) enum ValueKind {
 #[derive(Debug, Clone)]
 pub(crate) struct LocatedString {
     loc: Loc,
+    decoded: SmolStr,
 }
 
 /// A Located (JSON) Value that combines the JSON Type of the value and the value's location within the input string
@@ -48,8 +134,22 @@ pub(crate) struct LocatedValue {
 
 impl LocatedString {
     /// Create a new `LocatedString`
-    pub(crate) fn new(loc: Loc) -> Self {
-        Self { loc }
+    pub(crate) fn new(loc: Loc) -> Result<Self, ParseError> {
+        let start = loc.start() + 1;
+        let end = loc.end() - 1;
+        #[expect(
+            clippy::string_slice,
+            reason = r#"By construction `start` and `end` are both at valid character boundaries and `start` <= `end`.
+                        The JSON parser ensures that `self.loc.start()` immediately preceeds a quotation mark (`"`) and
+                        `self.loc.end()` immediately follows a quotation mark (`"`). In addition, the parser ensures that
+                        these are separate distinct quotation marks (`"`)."#
+        )]
+        let raw = &loc.src[start..end];
+        let decoded = match decode_json_escapes(raw, &loc)? {
+            Some(s) => SmolStr::from(s),
+            None => SmolStr::from(raw),
+        };
+        Ok(Self { loc, decoded })
     }
 
     /// Get a reference to the location of the `LocatedString` within the input string
@@ -62,33 +162,24 @@ impl LocatedString {
         self.loc
     }
 
-    /// Get the `&str` matching the contents of the `LocatedString`
+    /// Get the `&str` matching the decoded contents of the `LocatedString`
     pub(crate) fn as_str(&self) -> &str {
-        let start = self.loc.start() + 1;
-        let end = self.loc.end() - 1;
-        #[expect(
-            clippy::string_slice,
-            reason = r#"By construction `start` and `end` are both at valid character boundaries and `start` <= `end`.
-                        The JSON parser ensures that `self.loc.start()` immediately preceeds a quotation mark (`"`) and
-                        `self.loc.end()` immediately follows a quotation mark (`"`). In addition, the parser ensures that
-                        these are separate distinct quotation marks (`"`)."#
-        )]
-        &self.loc.src[start..end]
+        &self.decoded
     }
 
-    /// Create a `String` matching the contents of the `LocatedString`
+    /// Create a `String` matching the decoded contents of the `LocatedString`
     #[expect(dead_code, reason = "Added for completeness.")]
     #[expect(
         clippy::inherent_to_string,
         reason = "Not provided as a proxy for display."
     )]
     pub(crate) fn to_string(&self) -> String {
-        self.as_str().to_string()
+        self.decoded.to_string()
     }
 
-    /// Create a `SmolStr` matching the contents of the `LocatedString`
+    /// Create a `SmolStr` matching the decoded contents of the `LocatedString`
     pub(crate) fn to_smolstr(&self) -> SmolStr {
-        self.as_str().into()
+        self.decoded.clone()
     }
 }
 
@@ -141,11 +232,25 @@ impl LocatedValue {
     }
 
     /// Create a new `LocatedValue` of kind String
-    pub(crate) fn new_string(loc: Loc) -> Self {
-        Self {
-            kind: ValueKind::String,
+    pub(crate) fn new_string(loc: Loc) -> Result<Self, ParseError> {
+        let start = loc.start() + 1;
+        let end = loc.end() - 1;
+        #[expect(
+            clippy::string_slice,
+            reason = r#"By construction `start` and `end` are both at valid character boundaries and `start` <= `end`.
+                        The JSON parser ensures that `self.loc.start()` immediately preceeds a quotation mark (`"`) and
+                        `self.loc.end()` immediately follows a quotation mark (`"`). In addition, the parser ensures that
+                        these are separate distinct quotation marks (`"`)."#
+        )]
+        let raw = &loc.src[start..end];
+        let decoded = match decode_json_escapes(raw, &loc)? {
+            Some(s) => SmolStr::from(s),
+            None => SmolStr::from(raw),
+        };
+        Ok(Self {
+            kind: ValueKind::String(decoded),
             loc,
-        }
+        })
     }
 
     /// Create a new `LocatedValue` of kind Array
@@ -234,26 +339,15 @@ impl LocatedValue {
 
     /// Returns if this `LocatedValue` is of kind String
     pub(crate) fn is_string(&self) -> bool {
-        matches!(self.kind, ValueKind::String)
+        matches!(self.kind, ValueKind::String(_))
     }
 
     /// Returns Some(str) if this `Located` value is of kind String
-    /// where str is the string literal corresponding to this LocatedValue.
+    /// where str is the decoded string literal corresponding to this LocatedValue.
     /// Otherwise, return None if not of kind String.
     pub(crate) fn get_str(&self) -> Option<&str> {
-        match self.kind {
-            ValueKind::String => {
-                let start = self.loc.start() + 1;
-                let end = self.loc.end() - 1;
-                #[expect(
-                    clippy::string_slice,
-                    reason = r#"By construction `start` and `end` are both at valid character boundaries and `start` <= `end`.
-                        The JSON parser ensures that `self.loc.start()` immediately preceeds a quotation mark (`"`) and
-                        `self.loc.end()` immediately follows a quotation mark (`"`). In addition, the parser ensures that
-                        these are separate distinct quotation marks (`"`)."#
-                )]
-                Some(&self.loc.src[start..end])
-            }
+        match &self.kind {
+            ValueKind::String(s) => Some(s.as_str()),
             _ => None,
         }
     }
@@ -322,7 +416,9 @@ mod tests {
         assert!(LocatedValue::new_bool(false, new_loc("false")).is_bool());
         assert!(!LocatedValue::new_null(new_loc("null")).is_bool());
         assert!(!LocatedValue::new_number(new_loc("0.1")).is_bool());
-        assert!(!LocatedValue::new_string(new_loc("my cool str")).is_bool());
+        assert!(!LocatedValue::new_string(new_loc("my cool str"))
+            .unwrap()
+            .is_bool());
         assert!(!LocatedValue::new_array(Vec::new(), new_loc("[]")).is_bool());
         assert!(!LocatedValue::new_object(LinkedHashMap::new(), new_loc("{}")).is_bool());
     }
@@ -340,7 +436,9 @@ mod tests {
         assert_matches!(LocatedValue::new_null(new_loc("null")).get_bool(), None);
         assert_matches!(LocatedValue::new_number(new_loc("0.1")).get_bool(), None);
         assert_matches!(
-            LocatedValue::new_string(new_loc("my cool str")).get_bool(),
+            LocatedValue::new_string(new_loc("my cool str"))
+                .unwrap()
+                .get_bool(),
             None
         );
         assert_matches!(
@@ -359,7 +457,9 @@ mod tests {
         assert!(!LocatedValue::new_bool(false, new_loc("false")).is_null());
         assert!(LocatedValue::new_null(new_loc("null")).is_null());
         assert!(!LocatedValue::new_number(new_loc("0.1")).is_null());
-        assert!(!LocatedValue::new_string(new_loc("my cool str")).is_null());
+        assert!(!LocatedValue::new_string(new_loc("my cool str"))
+            .unwrap()
+            .is_null());
         assert!(!LocatedValue::new_array(Vec::new(), new_loc("[]")).is_null());
         assert!(!LocatedValue::new_object(LinkedHashMap::new(), new_loc("{}")).is_null());
     }
@@ -370,7 +470,9 @@ mod tests {
         assert!(!LocatedValue::new_bool(false, new_loc("false")).is_number());
         assert!(!LocatedValue::new_null(new_loc("null")).is_number());
         assert!(LocatedValue::new_number(new_loc("0.1")).is_number());
-        assert!(!LocatedValue::new_string(new_loc("my cool str")).is_number());
+        assert!(!LocatedValue::new_string(new_loc("my cool str"))
+            .unwrap()
+            .is_number());
         assert!(!LocatedValue::new_array(Vec::new(), new_loc("[]")).is_number());
         assert!(!LocatedValue::new_object(LinkedHashMap::new(), new_loc("{}")).is_number());
     }
@@ -394,7 +496,9 @@ mod tests {
             Some(..)
         );
         assert_matches!(
-            LocatedValue::new_string(new_loc("my cool str")).get_numeric_str(),
+            LocatedValue::new_string(new_loc("my cool str"))
+                .unwrap()
+                .get_numeric_str(),
             None
         );
         assert_matches!(
@@ -413,7 +517,9 @@ mod tests {
         assert!(!LocatedValue::new_bool(false, new_loc("false")).is_string());
         assert!(!LocatedValue::new_null(new_loc("null")).is_string());
         assert!(!LocatedValue::new_number(new_loc("0.1")).is_string());
-        assert!(LocatedValue::new_string(new_loc("my cool str")).is_string());
+        assert!(LocatedValue::new_string(new_loc("my cool str"))
+            .unwrap()
+            .is_string());
         assert!(!LocatedValue::new_array(Vec::new(), new_loc("[]")).is_string());
         assert!(!LocatedValue::new_object(LinkedHashMap::new(), new_loc("{}")).is_string());
     }
@@ -431,7 +537,9 @@ mod tests {
         assert_matches!(LocatedValue::new_null(new_loc("null")).get_str(), None);
         assert_matches!(LocatedValue::new_number(new_loc("0.1")).get_str(), None);
         assert_matches!(
-            LocatedValue::new_string(new_loc("my cool str")).get_str(),
+            LocatedValue::new_string(new_loc("my cool str"))
+                .unwrap()
+                .get_str(),
             Some(..)
         );
         assert_matches!(
@@ -457,7 +565,9 @@ mod tests {
         assert_matches!(LocatedValue::new_null(new_loc("null")).get_string(), None);
         assert_matches!(LocatedValue::new_number(new_loc("0.1")).get_string(), None);
         assert_matches!(
-            LocatedValue::new_string(new_loc("my cool str")).get_string(),
+            LocatedValue::new_string(new_loc("my cool str"))
+                .unwrap()
+                .get_string(),
             Some(..)
         );
         assert_matches!(
@@ -483,7 +593,9 @@ mod tests {
         assert_matches!(LocatedValue::new_null(new_loc("null")).get_smolstr(), None);
         assert_matches!(LocatedValue::new_number(new_loc("0.1")).get_smolstr(), None);
         assert_matches!(
-            LocatedValue::new_string(new_loc("my cool str")).get_smolstr(),
+            LocatedValue::new_string(new_loc("my cool str"))
+                .unwrap()
+                .get_smolstr(),
             Some(..)
         );
         assert_matches!(
@@ -502,7 +614,9 @@ mod tests {
         assert!(!LocatedValue::new_bool(false, new_loc("false")).is_array());
         assert!(!LocatedValue::new_null(new_loc("null")).is_array());
         assert!(!LocatedValue::new_number(new_loc("0.1")).is_array());
-        assert!(!LocatedValue::new_string(new_loc("my cool str")).is_array());
+        assert!(!LocatedValue::new_string(new_loc("my cool str"))
+            .unwrap()
+            .is_array());
         assert!(LocatedValue::new_array(Vec::new(), new_loc("[]")).is_array());
         assert!(!LocatedValue::new_object(LinkedHashMap::new(), new_loc("{}")).is_array());
     }
@@ -520,7 +634,9 @@ mod tests {
         assert_matches!(LocatedValue::new_null(new_loc("null")).get_array(), None);
         assert_matches!(LocatedValue::new_number(new_loc("0.1")).get_array(), None);
         assert_matches!(
-            LocatedValue::new_string(new_loc("my cool str")).get_array(),
+            LocatedValue::new_string(new_loc("my cool str"))
+                .unwrap()
+                .get_array(),
             None
         );
         assert_matches!(
@@ -539,7 +655,9 @@ mod tests {
         assert!(!LocatedValue::new_bool(false, new_loc("false")).is_object());
         assert!(!LocatedValue::new_null(new_loc("null")).is_object());
         assert!(!LocatedValue::new_number(new_loc("0.1")).is_object());
-        assert!(!LocatedValue::new_string(new_loc("my cool str")).is_object());
+        assert!(!LocatedValue::new_string(new_loc("my cool str"))
+            .unwrap()
+            .is_object());
         assert!(!LocatedValue::new_array(Vec::new(), new_loc("[]")).is_object());
         assert!(LocatedValue::new_object(LinkedHashMap::new(), new_loc("{}")).is_object());
     }
@@ -557,7 +675,9 @@ mod tests {
         assert_matches!(LocatedValue::new_null(new_loc("null")).get_object(), None);
         assert_matches!(LocatedValue::new_number(new_loc("0.1")).get_object(), None);
         assert_matches!(
-            LocatedValue::new_string(new_loc("my cool str")).get_object(),
+            LocatedValue::new_string(new_loc("my cool str"))
+                .unwrap()
+                .get_object(),
             None
         );
         assert_matches!(


### PR DESCRIPTION
## Description of changes

Makes the JSON parser decode strings as specified in RFC 8259, with a choice to return errors when decoding unicode fails rather than adding `\uFFFD`


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A bug fix or other functionality change requiring a patch to any crates.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
