### PR TITLE
fix float entity display

### DIFF
--- a/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Adds `deduplicate_entity_types` option to consolidate equivalent enum entity types (same name and variants) and leaf entity types (entities where all attributes are of base type, i.e. no nested entity) into a single definition at the lowest common ancestor namespace.
--
+
 ### Changed
 - Translation of JSON numbers to Cedar decimals does not special case integers (represents both `10` and `10.0` as `10.0000`)
+
+### Fixed
+- Float entity IDs now use a canonical lossless representation, fixing whole-number floats missing a decimal point and extreme values producing excessively long EIDs.
 
 ## [0.5.0] - 2026-05-12
 

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
@@ -382,7 +382,7 @@ impl RequestGenerator {
                 } else {
                     let ty = EntityType::from(Name::from(identifiers::FLOAT_TYPE.clone()));
                     let ty = ty.qualify_with(self.root_namespace.as_ref());
-                    let eid = Eid::new(format!("{}", f));
+                    let eid = Eid::new(format!("{:?}", f));
                     let euid = EntityUID::from_components(ty, eid, None);
                     Ok((RestrictedExpr::val(euid), Entities::new()))
                 }
@@ -1314,7 +1314,7 @@ mod test {
 
         test_value_to_cedar_is_expr(
             &TypedValue::Float(0.0),
-            &RestrictedExpr::from_str("Test::Float::\"0\"").unwrap(),
+            &RestrictedExpr::from_str("Test::Float::\"0.0\"").unwrap(),
             &Entities::new(),
         );
 
@@ -1329,6 +1329,59 @@ mod test {
             &RestrictedExpr::from_str("Test::Float::\"-1.05\"").unwrap(),
             &Entities::new(),
         );
+
+        // Whole-number floats must include decimal point in EID
+        test_value_to_cedar_is_expr(
+            &TypedValue::Float(1.0),
+            &RestrictedExpr::from_str("Test::Float::\"1.0\"").unwrap(),
+            &Entities::new(),
+        );
+
+        test_value_to_cedar_is_expr(
+            &TypedValue::Float(-42.0),
+            &RestrictedExpr::from_str("Test::Float::\"-42.0\"").unwrap(),
+            &Entities::new(),
+        );
+
+        // Extreme values must use scientific notation (not hundreds of digits)
+        test_value_to_cedar_is_expr(
+            &TypedValue::Float(f64::MIN_POSITIVE),
+            &RestrictedExpr::from_str("Test::Float::\"2.2250738585072014e-308\"").unwrap(),
+            &Entities::new(),
+        );
+
+        test_value_to_cedar_is_expr(
+            &TypedValue::Float(f64::MAX),
+            &RestrictedExpr::from_str("Test::Float::\"1.7976931348623157e308\"").unwrap(),
+            &Entities::new(),
+        );
+
+        // Adjacent floats must produce distinct EIDs
+        {
+            let request_generator = get_schema_generator(SchemaGeneratorConfig::default())
+                .new_request_generator()
+                .expect("Failed to construct request generator");
+            let type_defs = TypeDefsInfo::new();
+            let namespace: Option<Name> = Some("Test".parse().unwrap());
+
+            let (expr_a, _) = request_generator
+                .val_to_cedar(
+                    &TypedValue::Float(1.0000000000000002),
+                    &type_defs,
+                    namespace.as_ref(),
+                    "test_type",
+                )
+                .unwrap();
+            let (expr_b, _) = request_generator
+                .val_to_cedar(
+                    &TypedValue::Float(1.0000000000000004),
+                    &type_defs,
+                    namespace.as_ref(),
+                    "test_type",
+                )
+                .unwrap();
+            assert_ne!(expr_a, expr_b, "Adjacent floats must produce distinct EIDs");
+        }
 
         test_value_to_cedar_is_expr(
             &TypedValue::Number(str_to_number("0.0")),


### PR DESCRIPTION
This changes how floats are converted to entity UIDs to generate shorter and more consistent UIDs. 
- Something that is a `1e300` (valid JSON) gets converted to a `1e300` entity UID, as opposed to a string with 300 zeroes before.
- A float `1.0` results in the UID `1.0`, as opposed to `1` before.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A bug fix or other functionality change requiring a patch to any crates.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).