### PR TITLE
document the public API of mcp-tools-sdk

### DIFF
--- a/rust/mcp-tools-sdk/CHANGELOG.md
+++ b/rust/mcp-tools-sdk/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Moved some inner error types of the `err` out of the public API. Callers should only be able to differentiate top-level error kinds and display their representation.
+
 ### Fixed
 - `PropertyType::Decimal` validation properly rejects inputs such as `1-0.2` and `-01.2` (`-` in the numbers and negative number with leading zeroes).
 - JSON parser now decodes JSON escape sequences in JSON strings.

--- a/rust/mcp-tools-sdk/src/data.rs
+++ b/rust/mcp-tools-sdk/src/data.rs
@@ -70,8 +70,9 @@ pub enum Value {
 
 #[derive(Debug, Clone)]
 /// An enum representing the result of validating a MCP tool argument / result in which
-/// the `Value` is tagged with the `PropertyType the` `Value` was validated against.
-/// For exampel string `Values` can be validated as a String, Enum, Decimal, Datetime, Duration or IpAddr.
+/// the `Value` is tagged with the `PropertyType` the `Value` was validated against.
+///
+/// For example string `Values` can be validated as a String, Enum, Decimal, Datetime, Duration or `IpAddr`.
 pub enum TypedValue {
     /// A `null` value
     Null,

--- a/rust/mcp-tools-sdk/src/data.rs
+++ b/rust/mcp-tools-sdk/src/data.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! The `data` modules defines data representations for the values in MCP tool inputs.
+
 use smol_str::{SmolStr, ToSmolStr};
 use std::collections::HashMap;
 use std::path::Path;
@@ -50,12 +52,19 @@ impl Number {
 
 #[derive(Debug, Clone)]
 /// An enum represeting the possible `Value`s a MCP tool argument / result may take.
+/// Those values are generally JSON Values.
 pub enum Value {
+    /// A JSON `null`
     Null,
+    /// A JSON boolean
     Bool(bool),
+    /// A JSON number
     Number(Number),
+    /// A JSON string
     String(SmolStr),
+    /// A JSON array
     Array(Vec<Value>),
+    /// A JSON object
     Map(HashMap<SmolStr, Value>),
 }
 
@@ -64,24 +73,40 @@ pub enum Value {
 /// the `Value` is tagged with the `PropertyType the` `Value` was validated against.
 /// For exampel string `Values` can be validated as a String, Enum, Decimal, Datetime, Duration or IpAddr.
 pub enum TypedValue {
+    /// A `null` value
     Null,
+    /// A `true` or `false` value
     Bool(bool),
+    /// An integer value, representable as an `i64`
     Integer(i64),
+    /// A floating point value, representable as a finite `f64`
     Float(f64),
+    /// A numeric value validated against `{"type": "number"}`, preserved as its raw string representation
     Number(Number),
+    /// A string value
     String(SmolStr),
+    /// A decimal number string (non-standard extension)
     Decimal(SmolStr),
+    /// A datetime string validated against `date` or `date-time` format
     Datetime(SmolStr),
+    /// A duration string validated against `duration` format
     Duration(SmolStr),
+    /// An IP address string validated against `ipv4` or `ipv6` format
     IpAddr(SmolStr),
+    /// A variant of a enum, represented as the name of the variant
     Enum(SmolStr),
+    /// An array of typed values
     Array(Vec<TypedValue>),
+    /// A fixed-length tuple of typed values
     Tuple(Vec<TypedValue>),
+    /// A value matching one variant of a union type
     Union {
         /// index of which type within union type this validates against
         index: usize,
+        /// The validated value
         value: Box<TypedValue>,
     },
+    /// An object with typed properties
     Object {
         /// properties that were explicitly defined by object's type schema
         properties: HashMap<SmolStr, TypedValue>,
@@ -89,10 +114,14 @@ pub enum TypedValue {
         /// but matched the object's `additionalProperty` type
         additional_properties: HashMap<SmolStr, TypedValue>,
     },
+    /// A value validated against a named type definition (`$ref`)
     Ref {
+        /// The name of the referenced type definition
         name: SmolStr,
+        /// The validated value
         val: Box<TypedValue>,
     },
+    /// A value whose type is unknown or unrecognized
     Unknown(Value),
 }
 
@@ -279,6 +308,7 @@ impl Input {
 }
 
 #[derive(Debug, Clone)]
+/// A struct representing a validated MCP `call/tool` request with typed arguments
 pub struct TypedInput {
     pub(crate) name: SmolStr,
     pub(crate) args: HashMap<SmolStr, TypedValue>,

--- a/rust/mcp-tools-sdk/src/description.rs
+++ b/rust/mcp-tools-sdk/src/description.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! This module defines representations for properties in MCP tools definitions.
+
 use smol_str::{SmolStr, ToSmolStr};
 use std::collections::HashMap;
 use std::path::Path;
@@ -24,7 +26,7 @@ use super::err::{DeserializationError, ValidationError};
 use super::parser;
 use super::validation::{validate_input, validate_output};
 
-/// The type a `Property` can take
+/// The type a `Property` can take: supported types in JSON Schema maps to PropertyTypes.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PropertyType {
     /// An unknown property type. Produced when the JSON Schema is a boolean or null,
@@ -56,30 +58,37 @@ pub enum PropertyType {
     Null,
     /// An enumeration: `{"type": "string", "enum": ["a", "b", ...]}` in JSON Schema.
     Enum {
+        /// The variants of the enum; an ordered list of strings
         variants: Vec<SmolStr>,
     },
     /// A homogeneous array: `{"type": "array", "items": <schema>}` in JSON Schema.
     Array {
+        /// The type of elements of the homogenous array
         element_ty: Box<PropertyType>,
     },
     /// A fixed-length tuple: `{"type": "array", "prefixItems": [...], "items": false}` in JSON Schema.
     /// Standard JSON Schema (2020-12 draft).
     Tuple {
+        /// The ordered list of types of each tuple element
         types: Vec<PropertyType>,
     },
     /// A union type: `{"anyOf": [...]}` or `{"oneOf": [...]}` in JSON Schema,
     /// or `{"type": ["string", "integer", ...]}` (type as array). Standard JSON Schema.
     Union {
+        /// The set of types in the union
         types: Vec<PropertyType>,
     },
     /// An object: `{"type": "object", "properties": {...}}` in JSON Schema.
     /// `additional_properties` corresponds to the `additionalProperties` keyword when it is a schema object.
     Object {
+        /// The properties defined in the object schema (both required and optional)
         properties: Vec<Property>,
+        /// The additional properties of this object
         additional_properties: Option<Box<PropertyType>>,
     },
     /// A reference to a reusable type definition: `{"$ref": "#/$defs/<name>"}` in JSON Schema.
     Ref {
+        /// The name of the type being referenced
         name: SmolStr,
     },
 }
@@ -125,6 +134,7 @@ impl Property {
         self.description.as_deref()
     }
 
+    /// Returns the [PropertyType] of this [Property]
     pub fn property_type(&self) -> &PropertyType {
         &self.prop_type
     }

--- a/rust/mcp-tools-sdk/src/description.rs
+++ b/rust/mcp-tools-sdk/src/description.rs
@@ -27,33 +27,58 @@ use super::validation::{validate_input, validate_output};
 /// The type a `Property` can take
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PropertyType {
+    /// An unknown property type. Produced when the JSON Schema is a boolean or null,
+    /// or when no recognized schema pattern is found.
     Unknown,
+    /// A boolean property: `{"type": "boolean"}` in JSON Schema.
     Bool,
+    /// An integer property: `{"type": "integer"}` in JSON Schema.
     Integer,
+    /// A floating point property: `{"type": "float"}` in JSON Schema.
+    /// Non-standard extension — not part of the JSON Schema specification.
     Float,
+    /// A number: `{"type": "number"}` in JSON Schema.
     Number,
+    /// A string property: `{"type": "string"}` in JSON Schema (with no recognized `format`).
     String,
+    /// A decimal number: `{"type": "string", "format": "decimal"}` in JSON Schema.
+    /// Non-standard extension — the `"decimal"` format is not part of the JSON Schema specification.
     Decimal,
+    /// A datetime: `{"type": "string", "format": "date"}` or `{"type": "string", "format": "date-time"}`
+    /// in JSON Schema. Both standard formats map to this variant.
     Datetime,
+    /// A duration: `{"type": "string", "format": "duration"}` in JSON Schema.
     Duration,
+    /// An IP address: `{"type": "string", "format": "ipv4"}` or `{"type": "string", "format": "ipv6"}`
+    /// in JSON Schema. Both standard formats map to this variant.
     IpAddr,
+    /// A null value: `{"type": "null"}` in JSON Schema.
     Null,
+    /// An enumeration: `{"type": "string", "enum": ["a", "b", ...]}` in JSON Schema.
     Enum {
         variants: Vec<SmolStr>,
     },
+    /// A homogeneous array: `{"type": "array", "items": <schema>}` in JSON Schema.
     Array {
         element_ty: Box<PropertyType>,
     },
+    /// A fixed-length tuple: `{"type": "array", "prefixItems": [...], "items": false}` in JSON Schema.
+    /// Standard JSON Schema (2020-12 draft).
     Tuple {
         types: Vec<PropertyType>,
     },
+    /// A union type: `{"anyOf": [...]}` or `{"oneOf": [...]}` in JSON Schema,
+    /// or `{"type": ["string", "integer", ...]}` (type as array). Standard JSON Schema.
     Union {
         types: Vec<PropertyType>,
     },
+    /// An object: `{"type": "object", "properties": {...}}` in JSON Schema.
+    /// `additional_properties` corresponds to the `additionalProperties` keyword when it is a schema object.
     Object {
         properties: Vec<Property>,
         additional_properties: Option<Box<PropertyType>>,
     },
+    /// A reference to a reusable type definition: `{"$ref": "#/$defs/<name>"}` in JSON Schema.
     Ref {
         name: SmolStr,
     },

--- a/rust/mcp-tools-sdk/src/description.rs
+++ b/rust/mcp-tools-sdk/src/description.rs
@@ -26,7 +26,7 @@ use super::err::{DeserializationError, ValidationError};
 use super::parser;
 use super::validation::{validate_input, validate_output};
 
-/// The type a `Property` can take: supported types in JSON Schema maps to PropertyTypes.
+/// The type a `Property` can take: supported types in JSON Schema maps to `PropertyTypes`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PropertyType {
     /// An unknown property type. Produced when the JSON Schema is a boolean or null,
@@ -134,13 +134,13 @@ impl Property {
         self.description.as_deref()
     }
 
-    /// Returns the [PropertyType] of this [Property]
+    /// Returns the [`PropertyType`] of this [`Property`]
     pub fn property_type(&self) -> &PropertyType {
         &self.prop_type
     }
 }
 
-/// Representation of a TypeDef used for defining `Property`s
+/// Representation of a `TypeDef` used for defining `Property`s
 #[derive(Debug, Clone)]
 pub struct PropertyTypeDef {
     pub(crate) name: SmolStr,
@@ -158,12 +158,12 @@ impl PropertyTypeDef {
         }
     }
 
-    /// Get the name of the TypeDef
+    /// Get the name of the `TypeDef`
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// Get the definition of the TypeDef
+    /// Get the definition of the `TypeDef`
     pub fn property_type(&self) -> &PropertyType {
         &self.prop_type
     }
@@ -174,19 +174,19 @@ impl PropertyTypeDef {
     }
 }
 
-/// Container for convienently representing a collection of TypeDefs
+/// Container for convienently representing a collection of `TypeDefs`
 #[derive(Debug, Clone)]
 pub(crate) struct PropertyTypeDefs {
     pub(crate) type_defs: HashMap<SmolStr, PropertyTypeDef>,
 }
 
 impl PropertyTypeDefs {
-    /// Create a new collection of TypeDefs
+    /// Create a new collection of `TypeDefs`
     pub(crate) fn new(type_defs: HashMap<SmolStr, PropertyTypeDef>) -> Self {
         Self { type_defs }
     }
 
-    /// Get the collection of TypeDefs
+    /// Get the collection of `TypeDefs`
     pub(crate) fn values(&self) -> impl Iterator<Item = &PropertyTypeDef> {
         self.type_defs.values()
     }
@@ -215,7 +215,7 @@ impl Parameters {
         self.properties.iter()
     }
 
-    /// Iterate over the TypeDefs defined within this `Parameters`
+    /// Iterate over the `TypeDefs` defined within this `Parameters`
     pub fn type_definitions(&self) -> impl Iterator<Item = &PropertyTypeDef> {
         self.type_defs.values()
     }
@@ -269,8 +269,8 @@ impl ToolDescription {
         &self.outputs
     }
 
-    /// Get the TypeDefs defined within this tool (i.e., TypeDefs shared between Input and Output Parameters)
-    /// This does not return the TypeDefs specific to either Input or Output Parameters.
+    /// Get the `TypeDefs` defined within this tool (i.e., `TypeDefs` shared between Input and Output Parameters)
+    /// This does not return the `TypeDefs` specific to either Input or Output Parameters.
     pub fn type_definitions(&self) -> impl Iterator<Item = &PropertyTypeDef> {
         self.type_defs.values()
     }
@@ -333,7 +333,7 @@ impl ServerDescription {
         self.tools.values()
     }
 
-    /// Get any TypeDefs defined within this ServerDescription (i.e., TypeDefs shared between tools)
+    /// Get any `TypeDefs` defined within this `ServerDescription` (i.e., `TypeDefs` shared between tools)
     pub fn type_definitions(&self) -> impl Iterator<Item = &PropertyTypeDef> {
         self.type_defs.values()
     }

--- a/rust/mcp-tools-sdk/src/err.rs
+++ b/rust/mcp-tools-sdk/src/err.rs
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+//! This module contains definitions for errors that can occur when deserializing a MCP server's
+//! tool descriptions.
+
 use super::parser::{json_value::LocatedValue, loc::Loc};
 use miette::Diagnostic;
 use smol_str::SmolStr;
@@ -22,6 +25,7 @@ use thiserror::Error;
 
 /// The type of errors that may be encountered during deserialization of an MCP Server / Tool Description
 #[derive(Error, Debug, Diagnostic)]
+#[allow(private_interfaces)]
 pub enum DeserializationError {
     /// Deserializer encountered an error while parsing a JSON Value
     #[error(transparent)]
@@ -120,7 +124,7 @@ impl DeserializationError {
 
 #[derive(Error, Debug)]
 #[error("Missing expected attribute")]
-pub struct MissingExpectedAttributeError {
+pub(crate) struct MissingExpectedAttributeError {
     loc: Loc,
     expected_key: String,
     aliases: Vec<String>,
@@ -166,7 +170,7 @@ impl Diagnostic for MissingExpectedAttributeError {
 /// The source location of an error
 #[derive(Debug, Error)]
 #[error("Problem found.")]
-pub struct LocationFound {
+pub(crate) struct LocationFound {
     src: Loc,
     label: String,
     msg: String,
@@ -197,7 +201,7 @@ impl Diagnostic for LocationFound {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum ContentType {
+pub(crate) enum ContentType {
     ServerDescription,
     ToolDescription,
     ToolParameters,
@@ -222,7 +226,7 @@ impl std::fmt::Display for ContentType {
 }
 
 #[derive(Debug)]
-pub struct ReadError {
+pub(crate) struct ReadError {
     file_name: PathBuf,
     error: String,
 }
@@ -232,12 +236,15 @@ pub struct ReadError {
     reason = "The attribute `cycle` is used implicitly in error message."
 )]
 #[derive(Debug)]
-pub struct TypeDefinitionCycle {
+pub(crate) struct TypeDefinitionCycle {
     cycle: Vec<SmolStr>,
 }
 
+/// The type of errors that may be encountered during validation of an MCP tool input or output
 #[derive(Error, Debug, Diagnostic)]
+#[allow(private_interfaces)]
 pub enum ValidationError {
+    /// The tool name in the input does not match the tool being validated against
     #[error(transparent)]
     #[diagnostic(
         code = "validation_error::mismatched_names",
@@ -245,6 +252,7 @@ pub enum ValidationError {
     )]
     MismatchedToolNames(MismatchedNamesError),
 
+    /// The requested tool was not found in the server description
     #[error(transparent)]
     #[diagnostic(
         code = "validation_error::tool_not_found",
@@ -252,6 +260,7 @@ pub enum ValidationError {
     )]
     ToolNotFound(ToolNotFoundError),
 
+    /// A required property is missing from the input object
     #[error(transparent)]
     #[diagnostic(
         code = "validation_error::missing_required_property",
@@ -259,6 +268,7 @@ pub enum ValidationError {
     )]
     MissingRequiredProperty(MissingRequiredPropertyError),
 
+    /// A value could not be parsed as a valid 64-bit integer
     #[error("Invalid Integer Literal: {}", .0.literal)]
     #[diagnostic(
         code = "validation_error::invalid_integer_literal",
@@ -266,6 +276,7 @@ pub enum ValidationError {
     )]
     InvalidIntegerLiteral(InvalidLiteralError),
 
+    /// A value could not be parsed as a valid 64-bit float
     #[error("Invalid Float Literal: {}", .0.literal)]
     #[diagnostic(
         code = "validation_error::invalid_float_literal",
@@ -273,6 +284,7 @@ pub enum ValidationError {
     )]
     InvalidFloatLiteral(InvalidLiteralError),
 
+    /// A string value is not a valid decimal literal
     #[error("Invalid Decimal Literal: {}", .0.literal)]
     #[diagnostic(
         code = "validation_error::invalid_decimal_literal",
@@ -280,6 +292,7 @@ pub enum ValidationError {
     )]
     InvalidDecimalLiteral(InvalidLiteralError),
 
+    /// A string value is not a valid datetime literal
     #[error("Invalid Datetime Literal: {}", .0.literal)]
     #[diagnostic(
         code = "validation_error::invalid_datetime_literal",
@@ -287,6 +300,7 @@ pub enum ValidationError {
     )]
     InvalidDatetimeLiteral(InvalidLiteralError),
 
+    /// A string value is not a valid duration literal
     #[error("Invalid Duration Literal: {}", .0.literal)]
     #[diagnostic(
         code = "validation_error::invalid_duration_literal",
@@ -294,6 +308,7 @@ pub enum ValidationError {
     )]
     InvalidDurationLiteral(InvalidLiteralError),
 
+    /// A string value is not a valid IP address literal
     #[error("Invalid IpAddr Literal: {}", .0.literal)]
     #[diagnostic(
         code = "validation_error::invalid_ipaddr_literal",
@@ -301,6 +316,7 @@ pub enum ValidationError {
     )]
     InvalidIpAddrLiteral(InvalidLiteralError),
 
+    /// A string value is not a valid variant of the expected enum type
     #[error("Invalid Enum Variant: {}", .0.literal)]
     #[diagnostic(
         code = "validation_error::invalid_enum_variant",
@@ -308,6 +324,7 @@ pub enum ValidationError {
     )]
     InvalidEnumVariant(InvalidLiteralError),
 
+    /// An array has the wrong number of elements for the expected tuple type
     #[error("Wrong number of elements for tuple: expected {} elements, found {}", .0.expected, .0.found)]
     #[diagnostic(
         code = "validation_error::wrong_tuple_size",
@@ -315,6 +332,7 @@ pub enum ValidationError {
     )]
     WrongTupleSize(WrongTupleSizeError),
 
+    /// A value does not match any variant of a union type
     #[error("Could not match value to union type")]
     #[diagnostic(
         code = "validation_error::invalid_value_for_union_type",
@@ -322,6 +340,7 @@ pub enum ValidationError {
     )]
     InvalidValueForUnionType,
 
+    /// An object contains a property not defined in its schema
     #[error("Unexpected property on object: {}", .0.name)]
     #[diagnostic(
         code = "validation_error::unexpected_property",
@@ -329,6 +348,7 @@ pub enum ValidationError {
     )]
     UnexpectedProperty(UnexpectedPropertyError),
 
+    /// A `$ref` references a type name not found in the type definitions
     #[error("Type {} not found in type definitions", .0.name)]
     #[diagnostic(
         code = "validation_error::unrecognized_type_name",
@@ -336,6 +356,7 @@ pub enum ValidationError {
     )]
     UnexpectedTypeName(UnexpectedTypeNameError),
 
+    /// A value does not match the expected property type
     #[error("Value does not match expected type")]
     #[diagnostic(
         code = "validation_error::invalid_value_for_type",
@@ -421,40 +442,40 @@ impl ValidationError {
 
 #[derive(Debug, Error)]
 #[error("Validating input/output for {tool_name} but found input for {input_for}")]
-pub struct MismatchedNamesError {
+pub(crate) struct MismatchedNamesError {
     tool_name: SmolStr,
     input_for: SmolStr,
 }
 
 #[derive(Debug, Error)]
 #[error("Validation failed because no tool named {tool_name} was found.")]
-pub struct ToolNotFoundError {
+pub(crate) struct ToolNotFoundError {
     tool_name: SmolStr,
 }
 
 #[derive(Debug, Error)]
 #[error("Validation failed because required property {property_name} is missing.")]
-pub struct MissingRequiredPropertyError {
+pub(crate) struct MissingRequiredPropertyError {
     property_name: SmolStr,
 }
 
 #[derive(Debug)]
-pub struct InvalidLiteralError {
+pub(crate) struct InvalidLiteralError {
     literal: String,
 }
 
 #[derive(Debug)]
-pub struct WrongTupleSizeError {
+pub(crate) struct WrongTupleSizeError {
     expected: usize,
     found: usize,
 }
 
 #[derive(Debug)]
-pub struct UnexpectedPropertyError {
+pub(crate) struct UnexpectedPropertyError {
     name: String,
 }
 
 #[derive(Debug)]
-pub struct UnexpectedTypeNameError {
+pub(crate) struct UnexpectedTypeNameError {
     name: String,
 }

--- a/rust/mcp-tools-sdk/src/err.rs
+++ b/rust/mcp-tools-sdk/src/err.rs
@@ -25,7 +25,10 @@ use thiserror::Error;
 
 /// The type of errors that may be encountered during deserialization of an MCP Server / Tool Description
 #[derive(Error, Debug, Diagnostic)]
-#[allow(private_interfaces)]
+#[expect(
+    private_interfaces,
+    reason = "public error type not exposing inner error structs"
+)]
 pub enum DeserializationError {
     /// Deserializer encountered an error while parsing a JSON Value
     #[error(transparent)]
@@ -242,7 +245,10 @@ pub(crate) struct TypeDefinitionCycle {
 
 /// The type of errors that may be encountered during validation of an MCP tool input or output
 #[derive(Error, Debug, Diagnostic)]
-#[allow(private_interfaces)]
+#[expect(
+    private_interfaces,
+    reason = "public error type not exposing inner error structs"
+)]
 pub enum ValidationError {
     /// The tool name in the input does not match the tool being validated against
     #[error(transparent)]

--- a/rust/mcp-tools-sdk/src/lib.rs
+++ b/rust/mcp-tools-sdk/src/lib.rs
@@ -24,7 +24,18 @@
 //! This library also includes a `ServerDescription` struct that represents a collection of MCP tool descriptions
 //! (i.e., the output of `list_tools` from an MCP Server).
 
-#![deny(missing_docs)]
+#![deny(
+    missing_docs,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::invalid_codeblock_attributes,
+    rustdoc::invalid_html_tags,
+    rustdoc::invalid_rust_codeblocks,
+    rustdoc::bare_urls,
+    clippy::doc_markdown,
+    clippy::doc_lazy_continuation,
+    clippy::too_long_first_doc_paragraph
+)]
 
 pub mod data;
 pub mod description;

--- a/rust/mcp-tools-sdk/src/lib.rs
+++ b/rust/mcp-tools-sdk/src/lib.rs
@@ -24,6 +24,8 @@
 //! This library also includes a `ServerDescription` struct that represents a collection of MCP tool descriptions
 //! (i.e., the output of `list_tools` from an MCP Server).
 
+#![deny(missing_docs)]
+
 pub mod data;
 pub mod description;
 mod deserializer;

--- a/rust/mcp-tools-sdk/src/parser.rs
+++ b/rust/mcp-tools-sdk/src/parser.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! This is a custom parser for JSON.
+
 pub mod err;
 pub(crate) mod json_parser;
 pub(crate) mod json_value;

--- a/rust/mcp-tools-sdk/src/parser/err.rs
+++ b/rust/mcp-tools-sdk/src/parser/err.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! This module contains definitions for errors that can occur when parsing text into JSON.
+
 use super::loc::Loc;
 use miette::Diagnostic;
 use thiserror::Error;

--- a/rust/mcp-tools-sdk/src/parser/json_value.rs
+++ b/rust/mcp-tools-sdk/src/parser/json_value.rs
@@ -343,7 +343,7 @@ impl LocatedValue {
     }
 
     /// Returns Some(str) if this `Located` value is of kind String
-    /// where str is the decoded string literal corresponding to this LocatedValue.
+    /// where str is the decoded string literal corresponding to this `LocatedValue`.
     /// Otherwise, return None if not of kind String.
     pub(crate) fn get_str(&self) -> Option<&str> {
         match &self.kind {
@@ -353,14 +353,14 @@ impl LocatedValue {
     }
 
     /// Returns Some(String) if this `Located` value is of kind String
-    /// where String is the string literal corresponding to this LocatedValue.
+    /// where String is the string literal corresponding to this `LocatedValue`.
     /// Otherwise, return None if not of kind String.
     pub(crate) fn get_string(&self) -> Option<String> {
         self.get_str().map(|s| s.to_string())
     }
 
-    /// Returns Some(SmolStr) if this `Located` value is of kind String
-    /// where SmolStr is the string literal corresponding to this LocatedValue.
+    /// Returns `Some(SmolStr)` if this [Located] value is of kind String
+    /// where [`SmolStr`] is the string literal corresponding to this [`LocatedValue`].
     /// Otherwise, return None if not of kind String.
     pub(crate) fn get_smolstr(&self) -> Option<SmolStr> {
         self.get_str().map(|s| s.into())
@@ -372,7 +372,7 @@ impl LocatedValue {
     }
 
     /// Returns Some(values) where values is an array of `LocatedValue`s
-    /// if this `LocatedValue` is of kind Array. Otherwise, returns None
+    /// if this `LocatedValue` is of kind Array. Otherwise, returns `None`
     pub(crate) fn get_array(&self) -> Option<&[LocatedValue]> {
         match &self.kind {
             ValueKind::Array(items) => Some(items),
@@ -385,8 +385,8 @@ impl LocatedValue {
         matches!(self.kind, ValueKind::Object(_))
     }
 
-    /// Returns Some(key_value_map) where key_value_map is a mapping from `LocatedString`s to
-    /// `LocatedValue`s if this `LocatedValue` is of kind Object. Otherwise, returns None
+    /// Returns `Some(key_value_map)` where `key_value_map` is a mapping from [`LocatedString`]s to
+    /// [`LocatedValue`]s if this [`LocatedValue`] is of kind Object. Otherwise, returns `None`
     pub(crate) fn get_object(&self) -> Option<&LinkedHashMap<LocatedString, LocatedValue>> {
         match &self.kind {
             ValueKind::Object(items) => Some(items),


### PR DESCRIPTION
While the crate is still experimental, we should clean up the public API.
This adds documentation to the public types and makes some error types private.

This should also prevent misinterpretation of some data structures.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
