### PR TITLE
fix typename parsing in request

### DIFF
--- a/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Float entity IDs now use a canonical lossless representation, fixing whole-number floats missing a decimal point and extreme values producing excessively long EIDs.
+- In the request and schema generators, property names in MCP tool inputs that result in multi-namespace type names are rejected.
 
 ## [0.5.0] - 2026-05-12
 

--- a/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Float entity IDs now use a canonical lossless representation, fixing whole-number floats missing a decimal point and extreme values producing excessively long EIDs.
-- In the request and schema generators, property names in MCP tool inputs that result in multi-namespace type names are rejected.
+- In the request generator, property names containing `::` in MCP tool inputs are now rejected. The schema generator already errored on such names; this fix makes the request generator consistent.
 
 ## [0.5.0] - 2026-05-12
 

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use cedar_policy_core::ast::{
     Context, Eid, Entity, EntityType, EntityUID, InternalName, Name, Request, RestrictedExpr,
+    UnreservedId,
 };
 use cedar_policy_core::entities::Entities;
 use cedar_policy_core::parser::err::ParseErrors;
@@ -491,7 +492,7 @@ impl RequestGenerator {
                 for (i, val) in vals.iter().enumerate() {
                     let sub_ty_name = format!("Proj{i}");
                     let name = format!("proj{i}").to_smolstr();
-                    let sub_namespace: Name = ty_name.parse()?;
+                    let sub_namespace: Name = ty_name.parse::<UnreservedId>()?.into();
                     let sub_namespace = sub_namespace.qualify_with_name(namespace);
                     let (expr, new_entities) =
                         self.val_to_cedar(val, type_defs, Some(&sub_namespace), &sub_ty_name)?;
@@ -508,7 +509,7 @@ impl RequestGenerator {
             TypedValue::Union { index, value } => {
                 let sub_ty_name = format!("TypeChoice{}", index);
                 let name = format!("typeChoice{}", index).to_smolstr();
-                let sub_namespace: Name = ty_name.parse()?;
+                let sub_namespace: Name = ty_name.parse::<UnreservedId>()?.into();
                 let sub_namespace = sub_namespace.qualify_with_name(namespace);
                 let (expr, entities) =
                     self.val_to_cedar(value, type_defs, Some(&sub_namespace), &sub_ty_name)?;
@@ -518,7 +519,7 @@ impl RequestGenerator {
                 properties,
                 additional_properties,
             } => {
-                let sub_namespace: Name = ty_name.parse()?;
+                let sub_namespace: Name = ty_name.parse::<UnreservedId>()?.into();
                 let sub_namespace = sub_namespace.qualify_with_name(namespace);
 
                 let mut entities = Entities::new();
@@ -595,7 +596,10 @@ impl RequestGenerator {
         ty_name: &str,
         namespace: Option<&Name>,
     ) -> Result<EntityType, ParseErrors> {
-        let ty: EntityType = ty_name.parse()?;
+        // Parse as UnreservedId first to reject names containing `::`
+        // which could inject entity types into unintended namespaces.
+        let id: UnreservedId = ty_name.parse()?;
+        let ty = EntityType::from(Name::from(id));
 
         if let Some(ref resolved) = self.resolved_dedup {
             let dedup_info = resolved.iter().find(|(fp, info)| {
@@ -2835,5 +2839,48 @@ mod test {
                 })
             })
         });
+    }
+
+    /// Regression test: property names containing `::` must be rejected to prevent
+    /// namespace injection. Previously these parsed as multi-component Cedar Names.
+    #[test]
+    fn test_namespace_injection_rejected() {
+        let request_generator = get_schema_generator(SchemaGeneratorConfig::default())
+            .new_request_generator()
+            .expect("Failed to construct request generator");
+
+        let type_defs = TypeDefsInfo::new();
+        let namespace = Some("Test".parse().unwrap());
+
+        // Each variant exercises a different code path that parses ty_name into a namespace:
+        // - Tuple/Union/Object: parse ty_name as sub_namespace
+        // - Enum: parse ty_name in resolved_ty to construct an EntityType
+        let vals: &[(&str, TypedValue)] = &[
+            ("Tuple", TypedValue::Tuple(vec![TypedValue::Bool(true)])),
+            (
+                "Union",
+                TypedValue::Union {
+                    index: 0,
+                    value: Box::new(TypedValue::Bool(true)),
+                },
+            ),
+            (
+                "Object",
+                TypedValue::Object {
+                    properties: HashMap::new(),
+                    additional_properties: HashMap::new(),
+                },
+            ),
+            ("Enum", TypedValue::Enum("variant".into())),
+        ];
+
+        for (label, val) in vals {
+            let result =
+                request_generator.val_to_cedar(val, &type_defs, namespace.as_ref(), "foo::bar");
+            assert!(
+                result.is_err(),
+                "ty_name with `::` should be rejected in {label}"
+            );
+        }
     }
 }

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
@@ -2841,6 +2841,24 @@ mod test {
         });
     }
 
+    /// Tuple values are converted to a Cedar record with projection fields.
+    #[test]
+    fn test_tuple_val_to_cedar() {
+        let request_generator = get_schema_generator(SchemaGeneratorConfig::default())
+            .new_request_generator()
+            .expect("Failed to construct request generator");
+
+        let type_defs = TypeDefsInfo::new();
+        let namespace = Some("Test".parse().unwrap());
+
+        let val = TypedValue::Tuple(vec![TypedValue::Bool(true), TypedValue::Integer(42)]);
+        let (expr, _entities) = request_generator
+            .val_to_cedar(&val, &type_defs, namespace.as_ref(), "myTuple")
+            .expect("Failed to convert Tuple to Cedar");
+
+        assert_eq!(expr.to_string(), "{proj0: true, proj1: 42}");
+    }
+
     /// Regression test: property names containing `::` must be rejected to prevent
     /// namespace injection. Previously these parsed as multi-component Cedar Names.
     #[test]

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -698,8 +698,9 @@ impl SchemaGenerator {
                 properties,
                 additional_properties,
             } => {
-                if let Ok(obj_name) = name.parse::<Name>() {
-                    let child_ns = Some(obj_name.qualify_with_name(namespace.as_ref()));
+                if let Ok(obj_name) = name.parse::<UnreservedId>() {
+                    let child_ns: Name = obj_name.into();
+                    let child_ns = Some(child_ns.qualify_with_name(namespace.as_ref()));
                     for prop in properties {
                         Self::collect_enum_fingerprints_from_property_type(
                             prop.name(),
@@ -736,8 +737,9 @@ impl SchemaGenerator {
                 );
             }
             PropertyType::Union { types } => {
-                if let Ok(union_name) = name.parse::<Name>() {
-                    let child_ns = Some(union_name.qualify_with_name(namespace.as_ref()));
+                if let Ok(union_name) = name.parse::<UnreservedId>() {
+                    let child_ns: Name = union_name.into();
+                    let child_ns = Some(child_ns.qualify_with_name(namespace.as_ref()));
                     for (i, ty) in types.iter().enumerate() {
                         let variant_name = format!("TypeChoice{i}");
                         Self::collect_enum_fingerprints_from_property_type(
@@ -750,8 +752,9 @@ impl SchemaGenerator {
                 }
             }
             PropertyType::Tuple { types } => {
-                if let Ok(tuple_name) = name.parse::<Name>() {
-                    let child_ns = Some(tuple_name.qualify_with_name(namespace.as_ref()));
+                if let Ok(tuple_name) = name.parse::<UnreservedId>() {
+                    let child_ns: Name = tuple_name.into();
+                    let child_ns = Some(child_ns.qualify_with_name(namespace.as_ref()));
                     for (i, ty) in types.iter().enumerate() {
                         let proj_name = format!("Proj{i}");
                         Self::collect_enum_fingerprints_from_property_type(

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -3142,11 +3142,18 @@ namespace Test2 {
         let root_nsdef = schema.0.get(&root_ns).expect("Expected namespace Test");
 
         // The enum "on"/"off" appears identically in both tools (inside union and tuple),
-        // so dedup should hoist a shared entity type to the root namespace.
+        // so dedup should hoist shared entity types to the root namespace.
         assert!(
-            root_nsdef.entity_types.len() > 2,
-            "Expected deduplicated entity types in root namespace, got: {:?}",
-            root_nsdef.entity_types.keys().collect::<Vec<_>>()
+            root_nsdef
+                .entity_types
+                .contains_key(&"TypeChoice0".parse().unwrap()),
+            "Expected deduplicated enum from union in root namespace"
+        );
+        assert!(
+            root_nsdef
+                .entity_types
+                .contains_key(&"Proj0".parse().unwrap()),
+            "Expected deduplicated enum from tuple in root namespace"
         );
     }
 }

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/schema.rs
@@ -3062,6 +3062,93 @@ namespace Test2 {
             "tool_a::Input should have local 'meta' common type"
         );
     }
+
+    /// Enum types nested inside Union and Tuple properties are deduplicated
+    /// across tools when they share the same name and variants.
+    #[test]
+    fn test_dedup_enum_inside_union_and_tuple() {
+        let schema_stub = test_schema_stub();
+        let config = SchemaGeneratorConfig::default().deduplicate_entity_types(true);
+
+        let tools_json = r#"{
+            "result": {
+                "tools": [
+                    {
+                        "name": "tool_a",
+                        "description": "Tool A",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "choice": {
+                                        "anyOf": [
+                                            { "type": "string", "enum": ["on", "off"] },
+                                            { "type": "integer" }
+                                        ]
+                                    },
+                                    "pair": {
+                                        "type": "array",
+                                        "prefixItems": [
+                                            { "type": "string", "enum": ["on", "off"] },
+                                            { "type": "integer" }
+                                        ],
+                                        "items": false
+                                    }
+                                },
+                                "required": ["choice", "pair"]
+                            }
+                        }
+                    },
+                    {
+                        "name": "tool_b",
+                        "description": "Tool B",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {
+                                    "choice": {
+                                        "anyOf": [
+                                            { "type": "string", "enum": ["on", "off"] },
+                                            { "type": "integer" }
+                                        ]
+                                    },
+                                    "pair": {
+                                        "type": "array",
+                                        "prefixItems": [
+                                            { "type": "string", "enum": ["on", "off"] },
+                                            { "type": "integer" }
+                                        ],
+                                        "items": false
+                                    }
+                                },
+                                "required": ["choice", "pair"]
+                            }
+                        }
+                    }
+                ]
+            }
+        }"#;
+
+        let description =
+            ServerDescription::from_json_str(tools_json).expect("Failed to parse tools JSON");
+        let mut generator = SchemaGenerator::new_with_config(schema_stub, config)
+            .expect("Failed to create schema generator");
+        generator
+            .add_actions_from_server_description(&description)
+            .expect("Failed to add server description");
+
+        let schema = generator.get_schema();
+        let root_ns = Some("Test".parse::<Name>().unwrap());
+        let root_nsdef = schema.0.get(&root_ns).expect("Expected namespace Test");
+
+        // The enum "on"/"off" appears identically in both tools (inside union and tuple),
+        // so dedup should hoist a shared entity type to the root namespace.
+        assert!(
+            root_nsdef.entity_types.len() > 2,
+            "Expected deduplicated entity types in root namespace, got: {:?}",
+            root_nsdef.entity_types.keys().collect::<Vec<_>>()
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This fixes how property names are parsed in the request and the schema generators. This is not a fix reachable in practice when using the schema generator (parsing was already erroring on `::`) but fixes the request generator to also do the same. 

## Checklist
The change in this PR is (choose one, and delete the other options):
- [x] A bug fix or other functionality change requiring a patch to any crates.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
