### PR TITLE
Updated crate versions cedar-policy-mcp-schema-generator to `0.6.0`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-mcp-schema-generator"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "cedar-policy-core",

--- a/rust/cedar-policy-mcp-schema-generator/Cargo.toml
+++ b/rust/cedar-policy-mcp-schema-generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cedar-policy-mcp-schema-generator"
 description = "Auto-Generates Cedar schemas from an MCP server's tool descriptions."
-version = "0.5.0"
+version = "0.6.0"
 
 #inherit rest from workspace
 edition.workspace = true


### PR DESCRIPTION
Bump cedar-policy-mcp-schema-generator to `0.6.0`