### PR TITLE
Updated cedar-policy-mcp-schema-generator's dependencies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
  "ipnet",
  "iso8601",
  "linked-hash-map",
- "mcp-tools-sdk",
+ "mcp-tools-sdk 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "miette",
  "nonempty",
  "serde",
@@ -315,7 +315,7 @@ name = "cedar-policy-mcp-schema-generator-wasm"
 version = "0.1.0"
 dependencies = [
  "cedar-policy-mcp-schema-generator",
- "mcp-tools-sdk",
+ "mcp-tools-sdk 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "wasm-bindgen",
@@ -898,6 +898,23 @@ dependencies = [
  "nonempty",
  "smol_str",
  "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "mcp-tools-sdk"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db9346d0ad6ad1908e20fb7a42fa63704c987824d64d9c11ee4438109dfa3cc"
+dependencies = [
+ "chrono",
+ "ipnet",
+ "iso8601",
+ "itertools",
+ "linked-hash-map",
+ "miette",
+ "nonempty",
+ "smol_str",
  "thiserror",
 ]
 

--- a/rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator" }
-mcp-tools-sdk = { path = "../mcp-tools-sdk" }
+mcp-tools-sdk = { version = "0.4.0" }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/cedar-policy-mcp-schema-generator/Cargo.toml
+++ b/rust/cedar-policy-mcp-schema-generator/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-mcp-tools-sdk = { path = "../mcp-tools-sdk", version = "*" }
+mcp-tools-sdk = { version = "0.4.0" }
 cedar-policy-core = "=4.11.0"
 miette = "7.6.0"
 linked-hash-map = "0.5.6"


### PR DESCRIPTION
Updates the dependencies in the cargo manifest file (Cargo.toml) for cedar-policy-mcp-schema-generator in the new release/cedar-policy-mcp-schema-generator-0.6.x branch.