### PR TITLE
fix mcp tool calling spec + two test on json escapes

### DIFF
--- a/rust/mcp-tools-sdk/CHANGELOG.md
+++ b/rust/mcp-tools-sdk/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `tools/call` request deserializer now accepts the MCP-standard field names `name`/`arguments` in addition to the legacy `tool`/`args`. Mixing conventions (e.g. `name` with `args`) is rejected.
+
 ## [0.4.0] - 2026-05-26
 
 ### Changed

--- a/rust/mcp-tools-sdk/src/data.rs
+++ b/rust/mcp-tools-sdk/src/data.rs
@@ -785,6 +785,71 @@ mod test {
         )
     }
 
+    #[test]
+    fn test_input_mcp_standard_field_names() {
+        // MCP spec uses "name" and "arguments"
+        // https://modelcontextprotocol.io/specification/draft/server/tools#calling-tools
+        let input = r#"{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+        "name": "test_tool",
+        "arguments": {
+            "arg1": 0
+        }
+    }
+}"#;
+        let input = Input::from_json_str(input).unwrap();
+        assert_eq!(input.name(), "test_tool");
+        assert!(input.get_args().count() == 1);
+        assert_matches!(
+            input.get_arg("arg1"),
+            Some(v)
+            if matches!(
+                v.to_owned(),
+                Value::Number(n)
+                if n.to_u64() == Some(0)
+            )
+        )
+    }
+
+    #[test]
+    fn test_input_mixed_name_with_args_errors() {
+        let input = r#"{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+        "name": "test_tool",
+        "args": { "arg1": 0 }
+    }
+}"#;
+        assert_matches!(
+            Input::from_json_str(input),
+            Err(DeserializationError::UnexpectedValue(e))
+            if format!("{e:?}").contains("Cannot mix field name conventions")
+        )
+    }
+
+    #[test]
+    fn test_input_mixed_tool_with_arguments_errors() {
+        let input = r#"{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+        "tool": "test_tool",
+        "arguments": { "arg1": 0 }
+    }
+}"#;
+        assert_matches!(
+            Input::from_json_str(input),
+            Err(DeserializationError::UnexpectedValue(e))
+            if format!("{e:?}").contains("Cannot mix field name conventions")
+        )
+    }
+
     //------------------- test Output ----------------------------
     #[test]
     fn test_simple_output_from_file() {

--- a/rust/mcp-tools-sdk/src/deserializer.rs
+++ b/rust/mcp-tools-sdk/src/deserializer.rs
@@ -525,6 +525,11 @@ fn get_value_from_map<'a, T: AsRef<str>>(
 }
 
 /// Deserialize an MCP `tools/call` json request into an `Input`
+///
+/// Per the [MCP specification](https://modelcontextprotocol.io/specification/draft/server/tools#calling-tools),
+/// the standard field names are `params.name` and `params.arguments`.
+/// For backwards compatibility, the legacy aliases `params.tool` and `params.args` are also accepted.
+/// Mixing conventions (e.g. `name` with `args`) is rejected.
 pub(crate) fn mcp_tool_input_from_json_value(
     json_value: &LocatedValue,
 ) -> Result<Input, DeserializationError> {
@@ -545,23 +550,35 @@ pub(crate) fn mcp_tool_input_from_json_value(
             ContentType::ToolInputRequest,
         )
     })?;
-    let tool = params_obj
-        .get("tool")
-        .ok_or_else(|| DeserializationError::missing_attribute(params, "tool", vec![]))?;
+
+    // Reject mixed field name conventions
+    let has_name = params_obj.get("name").is_some();
+    let has_tool = params_obj.get("tool").is_some();
+    let has_arguments = params_obj.get("arguments").is_some();
+    let has_args = params_obj.get("args").is_some();
+    if (has_name && has_args) || (has_tool && has_arguments) {
+        return Err(DeserializationError::unexpected_value(
+            params,
+            "Cannot mix field name conventions: use either `name`/`arguments` (MCP standard) or `tool`/`args` (legacy), not a combination.",
+            ContentType::ToolInputRequest,
+        ));
+    }
+
+    let tool = get_value_from_map(params_obj, &["name", "tool"])
+        .ok_or_else(|| DeserializationError::missing_attribute(params, "name", vec![]))?;
     let tool = tool.get_smolstr().ok_or_else(|| {
         DeserializationError::unexpected_type(
             tool,
-            "Expected \"tool\" attribute to be a string",
+            "Expected \"name\" attribute to be a string",
             ContentType::ToolInputRequest,
         )
     })?;
-    let args = params_obj
-        .get("args")
-        .ok_or_else(|| DeserializationError::missing_attribute(params, "args", vec![]))?;
+    let args = get_value_from_map(params_obj, &["arguments", "args"])
+        .ok_or_else(|| DeserializationError::missing_attribute(params, "arguments", vec![]))?;
     let args = args.get_object().ok_or_else(|| {
         DeserializationError::unexpected_type(
             args,
-            "Expected \"args\" attribute to be an object",
+            "Expected \"arguments\" attribute to be an object",
             ContentType::ToolInputRequest,
         )
     })?;

--- a/rust/mcp-tools-sdk/src/parser/json_parser.rs
+++ b/rust/mcp-tools-sdk/src/parser/json_parser.rs
@@ -532,4 +532,20 @@ mod tests {
         let mut parser = JsonParser::new("{\"hi\": true,");
         assert_matches!(parser.get_value(), Err(ParseError::TokenizeError(..)))
     }
+
+    #[test]
+    fn parse_fail_duplicate_keys_unicode_escape() {
+        // "a" and "\u0061" are the same decoded string
+        let mut parser = JsonParser::new(r#"{"\u0061": true, "a": false}"#);
+        assert_matches!(parser.get_value(), Err(ParseError::DuplicateKey(..)));
+    }
+
+    #[test]
+    fn parse_fail_duplicate_keys_backslash_escape() {
+        // JSON: {"\\": true, "\u005c": false}
+        // Both keys decode to a single backslash character
+        let input = "{\"\\\\\":true,\"\\u005c\":false}";
+        let mut parser = JsonParser::new(input);
+        assert_matches!(parser.get_value(), Err(ParseError::DuplicateKey(..)));
+    }
 }


### PR DESCRIPTION
## Description of changes
This fixes how MCP tool calls are parsed by the mcp-tools-sdk to follow the MCP spec. This previous schema is still allowed for backwards compatibility. 

Also adds two unrelated tests checking that JSON escapes are properly handled in JSON keys.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A bug fix or other functionality change requiring a patch to any crates.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).