### PR TITLE
chore: add npm publish path for MCP schema generator WASM

### DIFF
--- a/.github/scripts/prepare_wasm_npm_package.mjs
+++ b/.github/scripts/prepare_wasm_npm_package.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const [pkgDirArg, cargoTomlArg] = process.argv.slice(2);
+
+if (!pkgDirArg || !cargoTomlArg) {
+  console.error(
+    "Usage: node .github/scripts/prepare_wasm_npm_package.mjs <pkg-dir> <Cargo.toml>",
+  );
+  process.exit(1);
+}
+
+const pkgDir = path.resolve(pkgDirArg);
+const cargoTomlPath = path.resolve(cargoTomlArg);
+const packageJsonPath = path.join(pkgDir, "package.json");
+
+const cargoToml = fs.readFileSync(cargoTomlPath, "utf8");
+const versionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
+
+if (!versionMatch) {
+  console.error(`Could not find package.version in ${cargoTomlPath}`);
+  process.exit(1);
+}
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const cargoVersion = versionMatch[1];
+
+packageJson.name = "@cedar-policy/mcp-schema-generator-wasm";
+packageJson.version = cargoVersion;
+packageJson.description =
+  "WASM bindings for generating Cedar schemas and authorization requests from MCP tool descriptions.";
+packageJson.license = "Apache-2.0";
+packageJson.repository = {
+  type: "git",
+  url: "https://github.com/cedar-policy/cedar-for-agents.git",
+  directory: "rust/cedar-policy-mcp-schema-generator-wasm",
+};
+packageJson.homepage =
+  "https://github.com/cedar-policy/cedar-for-agents/tree/main/rust/cedar-policy-mcp-schema-generator-wasm";
+packageJson.keywords = ["cedar", "authorization", "agents", "mcp", "wasm"];
+packageJson.sideEffects = false;
+
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+console.log(`Prepared ${packageJson.name}@${packageJson.version} in ${pkgDir}`);

--- a/.github/scripts/prepare_wasm_npm_package.mjs
+++ b/.github/scripts/prepare_wasm_npm_package.mjs
@@ -41,8 +41,13 @@ if (!versionMatch) {
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 const cargoVersion = versionMatch[1];
+const packageName = "@cedar-policy/mcp-schema-generator-wasm";
 
-packageJson.name = "@cedar-policy/mcp-schema-generator-wasm";
+// wasm-pack derives scoped package names from the Rust crate name. Since this
+// crate already carries the repository prefix, the derived scoped name would be
+// @cedar-policy/cedar-policy-mcp-schema-generator-wasm. Normalize it to the
+// shorter package name documented for JavaScript consumers.
+packageJson.name = packageName;
 packageJson.version = cargoVersion;
 packageJson.description =
   "WASM bindings for generating Cedar schemas and authorization requests from MCP tool descriptions.";

--- a/.github/workflows/publish_wasm_npm.yml
+++ b/.github/workflows/publish_wasm_npm.yml
@@ -1,0 +1,103 @@
+# This workflow publishes the WASM bindings for cedar-policy-mcp-schema-generator
+# to npm. It must be triggered from main and pointed at a pre-created release tag.
+name: Publish MCP schema generator WASM to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: >
+          GitHub tag to release. Must be of the form
+          'cedar-policy-mcp-schema-generator-wasm-v<MAJOR>.<MINOR>.<PATCH>'.
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch
+        if: github.ref != 'refs/heads/main'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: core.setFailed('This workflow must be triggered from the "main" branch.')
+
+      - name: Validate tag format
+        shell: bash
+        run: |
+          REGEX_PATTERN='^cedar-policy-mcp-schema-generator-wasm-v[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ ! "$TAG_NAME" =~ $REGEX_PATTERN ]]; then
+            echo "Specified tag must match $REGEX_PATTERN"
+            exit 1
+          fi
+        env:
+          TAG_NAME: ${{ inputs.tag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Validate package version
+        shell: bash
+        run: |
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml | head -1)
+          EXPECTED="cedar-policy-mcp-schema-generator-wasm-v${VERSION}"
+          if [[ "$EXPECTED" != "$TAG_NAME" ]]; then
+            echo "Tag $TAG_NAME does not match Cargo.toml version $VERSION"
+            echo "Expected $EXPECTED"
+            exit 1
+          fi
+        env:
+          TAG_NAME: ${{ inputs.tag }}
+
+  publish-npm:
+    needs: [validate]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Configure Rust toolchain
+        run: rustup update stable && rustup default stable
+
+      - name: Configure Node.js registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@cedar-policy"
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Build WASM npm package
+        run: >-
+          wasm-pack build .
+          --target nodejs
+          --scope cedar-policy
+          --out-dir pkg
+        working-directory: rust/cedar-policy-mcp-schema-generator-wasm
+
+      - name: Normalize npm package metadata
+        run: >-
+          node .github/scripts/prepare_wasm_npm_package.mjs
+          rust/cedar-policy-mcp-schema-generator-wasm/pkg
+          rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml
+
+      - name: Validate npm package contents
+        run: npm pack --dry-run
+        working-directory: rust/cedar-policy-mcp-schema-generator-wasm/pkg
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        working-directory: rust/cedar-policy-mcp-schema-generator-wasm/pkg
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_wasm_npm.yml
+++ b/.github/workflows/publish_wasm_npm.yml
@@ -12,9 +12,7 @@ on:
           GitHub tag to release. Must be of the form
           'cedar-policy-mcp-schema-generator-wasm-v<MAJOR>.<MINOR>.<PATCH>'.
 
-permissions:
-  contents: read
-  id-token: write
+permissions: read-all
 
 jobs:
   validate:
@@ -55,10 +53,54 @@ jobs:
         env:
           TAG_NAME: ${{ inputs.tag }}
 
+  compute-values:
+    runs-on: ubuntu-latest
+    outputs:
+      npm_tag: ${{ steps.compute_npm_tag.outputs.npm_tag }}
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "latest"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install NPM dependencies
+        run: npm install compare-versions@6.1.1
+
+      - name: Get latest NPM version
+        id: latest_npm_version
+        shell: bash
+        run: |
+          LATEST_VERSION=$(npm view @cedar-policy/mcp-schema-generator-wasm version 2>/dev/null || echo "0.0.0")
+          echo "latest_npm_version=${LATEST_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute NPM tag
+        id: compute_npm_tag
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const compareVersions = require('compare-versions');
+            const tag = '${{ inputs.tag }}';
+            const version = tag.replace('cedar-policy-mcp-schema-generator-wasm-v', '');
+            const [major, minor] = version.split('.');
+            const latestRelease = '${{ steps.latest_npm_version.outputs.latest_npm_version }}';
+            console.log(`Latest version found on NPM: ${latestRelease}`);
+            let npmTag;
+            if (compareVersions.compare(version, latestRelease, '<=')) {
+              npmTag = `v${major}.${minor}-x`;
+            } else {
+              npmTag = 'latest';
+            }
+            console.log(`Using NPM tag: ${npmTag}`);
+            core.setOutput('npm_tag', npmTag);
+
   publish-npm:
-    needs: [validate]
+    needs: [validate, compute-values]
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -69,9 +111,9 @@ jobs:
         run: rustup update stable && rustup default stable
 
       - name: Configure Node.js registry
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "latest"
           registry-url: "https://registry.npmjs.org"
           scope: "@cedar-policy"
 
@@ -97,7 +139,7 @@ jobs:
         working-directory: rust/cedar-policy-mcp-schema-generator-wasm/pkg
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --access public --tag "$NPM_TAG" --provenance
         working-directory: rust/cedar-policy-mcp-schema-generator-wasm/pkg
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TAG: ${{ needs.compute-values.outputs.npm_tag }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains a number of directories:
 * [rust](./rust/) which contains the source code for a number of Rust crates that provide functionality to secure Agentic workflows using Cedar.
   - [mcp-tools-sdk](./rust/mcp-tools-sdk/) : A crate for parsing and manipulating MCP tool descriptions and data.
   - [cedar-policy-mcp-schema-generator](./rust/cedar-policy-mcp-schema-generator/) : A crate for auto-generating a Cedar Schema for an MCP Server's tool descriptions.
+  - [cedar-policy-mcp-schema-generator-wasm](./rust/cedar-policy-mcp-schema-generator-wasm/) : WebAssembly bindings for generating Cedar schemas and authorization requests from MCP tool descriptions in JavaScript and TypeScript environments.
 * [js](./js/) which contains JavaScript packages that enable Agents to make use of Cedar and its Analysis Capabilities.
   - [cedar-analysis-mcp-server](./js/cedar-analysis-mcp-server) : A package that creates an MCP server that exposes an interface for Agents to use [Cedar's analysis capabilities](https://github.com/cedar-policy/cedar-spec/tree/main/cedar-lean-cli#analysis).
 

--- a/rust/cedar-policy-mcp-schema-generator-wasm/README.md
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/README.md
@@ -10,6 +10,12 @@ This enables Node.js and browser environments to generate Cedar authorization sc
 
 ## Usage
 
+Install the npm package:
+
+```bash
+npm install @cedar-policy/mcp-schema-generator-wasm
+```
+
 ```javascript
 const { generateSchema } = require('@cedar-policy/mcp-schema-generator-wasm');
 
@@ -99,6 +105,33 @@ wasm-pack build --target nodejs --scope cedar-policy
 # Build for browsers
 wasm-pack build --target web --scope cedar-policy
 ```
+
+## npm Release
+
+The npm package name is:
+
+```text
+@cedar-policy/mcp-schema-generator-wasm
+```
+
+The Rust crate name remains `cedar-policy-mcp-schema-generator-wasm`. During
+release, the generated `wasm-pack` package metadata is normalized so the npm
+package uses the shorter name above while preserving the `Cargo.toml` version.
+
+Releases are performed manually through the
+`Publish MCP schema generator WASM to npm` GitHub Actions workflow. The workflow:
+
+1. validates that it is triggered from `main`;
+2. validates a tag of the form
+   `cedar-policy-mcp-schema-generator-wasm-v<MAJOR>.<MINOR>.<PATCH>`;
+3. checks that the tag version matches this crate's `Cargo.toml`;
+4. runs `wasm-pack build --target nodejs --scope cedar-policy`;
+5. normalizes the generated npm package metadata;
+6. runs `npm pack --dry-run`; and
+7. publishes with `npm publish --access public --provenance`.
+
+The workflow expects npm authentication to be provided by the repository's
+release environment via the `NPM_TOKEN` secret.
 
 ## Relationship to the Rust Generator
 

--- a/rust/cedar-policy-mcp-schema-generator-wasm/README.md
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/README.md
@@ -128,10 +128,11 @@ Releases are performed manually through the
 4. runs `wasm-pack build --target nodejs --scope cedar-policy`;
 5. normalizes the generated npm package metadata;
 6. runs `npm pack --dry-run`; and
-7. publishes with `npm publish --access public --provenance`.
+7. computes the correct npm dist-tag; and
+8. publishes with `npm publish --access public --tag <tag> --provenance`.
 
-The workflow expects npm authentication to be provided by the repository's
-release environment via the `NPM_TOKEN` secret.
+The workflow expects npm authentication to use npm trusted publishing through
+the repository's release environment. It does not require an `NPM_TOKEN` secret.
 
 ## Relationship to the Rust Generator
 


### PR DESCRIPTION
Closes #124.

## Summary
- Add a manual GitHub Actions workflow to publish the WASM bindings to npm.
- Normalize the generated `wasm-pack` package metadata to `@cedar-policy/mcp-schema-generator-wasm`, matching #124 while keeping the Rust crate name unchanged.
- Validate tag format and `Cargo.toml` version before publishing.
- Run `wasm-pack build`, normalize metadata, and `npm pack --dry-run` before `npm publish --access public --provenance`.
- Update the root README and WASM README with the npm package name and release flow.

## Notes
This PR adds release plumbing only. It does not publish the package and does not handle npm org credentials. The workflow expects maintainers to provide npm authentication through the release environment via `NPM_TOKEN`.

I used `@cedar-policy/mcp-schema-generator-wasm` to match #124. Happy to adjust if maintainers prefer mirroring the Rust crate name exactly.

## Verification
- `node --check .github/scripts/prepare_wasm_npm_package.mjs`
- metadata script smoke-tested against a fake `wasm-pack` package.json
- `git diff --check`