### PR TITLE
add missing deduplicateEntityTypes config, deny_unknown_fields option…

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -315,9 +315,11 @@ name = "cedar-policy-mcp-schema-generator-wasm"
 version = "0.1.0"
 dependencies = [
  "cedar-policy-mcp-schema-generator",
+ "getrandom",
  "mcp-tools-sdk",
  "serde",
  "serde_json",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -622,10 +624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml
@@ -20,6 +20,8 @@ mcp-tools-sdk = { path = "../mcp-tools-sdk" }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+uuid = { version = "1.23.1", features = ["js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/rust/cedar-policy-mcp-schema-generator-wasm/README.md
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/README.md
@@ -75,7 +75,8 @@ if (result.isOk) {
   "objectsAsRecords": false,
   "eraseAnnotations": true,
   "flattenNamespaces": false,
-  "numbersAsDecimal": false
+  "numbersAsDecimal": false,
+  "deduplicateEntityTypes": false
 }
 ```
 
@@ -86,6 +87,81 @@ if (result.isOk) {
 | `eraseAnnotations` | `true` | Remove `@mcp_*` annotations from output |
 | `flattenNamespaces` | `false` | Flatten all types into a single namespace |
 | `numbersAsDecimal` | `false` | Encode JSON `number` as Cedar `Decimal` instead of `Long` |
+| `deduplicateEntityTypes` | `false` | Consolidate identical entity types across tools into the lowest common ancestor namespace |
+
+### `generateRequest(schemaStub, toolsJson, inputJson, principalType, principalId, resourceType, resourceId, configJson?)`
+
+Generates Cedar authorization request components from an MCP tool call.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `schemaStub` | `string` | Cedar schema stub (same as `generateSchema`) |
+| `toolsJson` | `string` | MCP tool descriptions as JSON |
+| `inputJson` | `string` | MCP tool call input (`{"params": {"tool": "...", "args": {...}}}`) |
+| `principalType` | `string` | Cedar entity type for the principal (e.g., `"User"`) |
+| `principalId` | `string` | Principal identifier (e.g., `"alice"`) |
+| `resourceType` | `string` | Cedar entity type for the resource (e.g., `"McpServer"`) |
+| `resourceId` | `string` | Resource identifier (e.g., `"my-server"`) |
+| `configJson` | `string?` | Optional configuration as JSON |
+
+**Returns:** JSON string with fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `principal` | `string \| null` | Principal EntityUID (e.g., `MyServer::User::"alice"`) |
+| `action` | `string \| null` | Action EntityUID (e.g., `MyServer::Action::"read_file"`) |
+| `resource` | `string \| null` | Resource EntityUID (e.g., `MyServer::McpServer::"my-server"`) |
+| `entitiesJson` | `string \| null` | Entities as a JSON array string |
+| `error` | `string \| null` | Error message if generation failed |
+| `isOk` | `boolean` | Whether generation succeeded |
+
+**Example:**
+
+```javascript
+const { generateRequest } = require('@cedar-policy/mcp-schema-generator-wasm');
+
+const stub = `
+namespace MyServer {
+    @mcp_principal
+    entity User;
+    @mcp_resource
+    entity McpServer;
+    action "call_tool" appliesTo {
+        principal: [User],
+        resource: [McpServer]
+    };
+}
+`;
+
+const tools = JSON.stringify([
+  {
+    name: 'read_file',
+    description: 'Read a file from disk',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    },
+  },
+]);
+
+const input = JSON.stringify({
+  params: { tool: 'read_file', args: { path: '/etc/config.yaml' } },
+});
+
+const result = JSON.parse(
+  generateRequest(stub, tools, input, 'User', 'alice', 'McpServer', 'my-server')
+);
+
+if (result.isOk) {
+  console.log(result.principal);    // MyServer::User::"alice"
+  console.log(result.action);       // MyServer::Action::"read_file"
+  console.log(result.resource);     // MyServer::McpServer::"my-server"
+  console.log(result.entitiesJson); // JSON array of entities for isAuthorized()
+} else {
+  console.error(result.error);
+}
+```
 
 ## Building
 

--- a/rust/cedar-policy-mcp-schema-generator-wasm/src/lib.rs
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/src/lib.rs
@@ -33,7 +33,7 @@ use wasm_bindgen::prelude::*;
 /// Configuration options for schema generation, matching the Rust
 /// [`SchemaGeneratorConfig`] options.
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct WasmConfig {
     #[serde(default)]
     include_outputs: bool,
@@ -45,6 +45,8 @@ struct WasmConfig {
     flatten_namespaces: bool,
     #[serde(default)]
     numbers_as_decimal: bool,
+    #[serde(default)]
+    deduplicate_entity_types: bool,
 }
 
 fn default_true() -> bool {
@@ -59,6 +61,7 @@ impl Default for WasmConfig {
             erase_annotations: true,
             flatten_namespaces: false,
             numbers_as_decimal: false,
+            deduplicate_entity_types: false,
         }
     }
 }
@@ -71,6 +74,7 @@ impl From<WasmConfig> for SchemaGeneratorConfig {
             .erase_annotations(c.erase_annotations)
             .flatten_namespaces(c.flatten_namespaces)
             .encode_numbers_as_decimal(c.numbers_as_decimal)
+            .deduplicate_entity_types(c.deduplicate_entity_types)
     }
 }
 
@@ -564,6 +568,7 @@ mod tests {
         assert!(config.erase_annotations);
         assert!(!config.flatten_namespaces);
         assert!(!config.numbers_as_decimal);
+        assert!(!config.deduplicate_entity_types);
     }
 
     #[test]
@@ -574,6 +579,7 @@ mod tests {
             erase_annotations: false,
             flatten_namespaces: true,
             numbers_as_decimal: true,
+            deduplicate_entity_types: true,
         };
         let _config: SchemaGeneratorConfig = wasm_config.into();
         // Conversion should not panic
@@ -723,7 +729,8 @@ mod coverage_tests {
             "includeOutputs": true,
             "objectsAsRecords": true,
             "eraseAnnotations": false,
-            "flattenNamespaces": true
+            "flattenNamespaces": true,
+            "deduplicateEntityTypes": true
         }"#;
 
         let result_json = generate_schema(STUB, tools, Some(config.to_string()));
@@ -873,6 +880,102 @@ mod coverage_tests {
 
         let result = generate_schema_inner(STUB, "[]", Some("{}"));
         assert!(result.is_ok);
+    }
+
+    #[test]
+    fn test_unknown_config_field_rejected() {
+        let config = r#"{"unknownOption": true}"#;
+        let result = generate_schema_inner(STUB, "[]", Some(config));
+        assert!(!result.is_ok);
+        assert!(
+            result.error.as_deref().unwrap().contains("Invalid config"),
+            "Should reject unknown fields, got: {:?}",
+            result.error
+        );
+    }
+
+    #[test]
+    fn test_deduplicate_entity_types_config() {
+        // Two tools share an identical enum; with deduplication enabled,
+        // the schema should contain only one entity type for the enum
+        // in the common namespace rather than one per tool.
+        let tools = r#"[
+            {
+                "name": "tool_a",
+                "description": "Tool A",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "status": { "type": "string", "enum": ["active", "inactive"] }
+                    }
+                }
+            },
+            {
+                "name": "tool_b",
+                "description": "Tool B",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "status": { "type": "string", "enum": ["active", "inactive"] }
+                    }
+                }
+            }
+        ]"#;
+
+        // Without deduplication: both tool namespaces get their own entity type.
+        let result_no_dedup = generate_schema_inner(STUB, tools, Some(r#"{"deduplicateEntityTypes": false}"#));
+        assert!(result_no_dedup.is_ok);
+        let schema_no_dedup = result_no_dedup.schema.unwrap();
+
+        // With deduplication: the enum should be deduplicated.
+        let result_dedup = generate_schema_inner(STUB, tools, Some(r#"{"deduplicateEntityTypes": true}"#));
+        assert!(result_dedup.is_ok, "Error: {:?}", result_dedup.error);
+        let schema_dedup = result_dedup.schema.unwrap();
+
+        // The deduplicated schema should be shorter (one shared type vs two).
+        assert!(
+            schema_dedup.len() <= schema_no_dedup.len(),
+            "Deduplicated schema should not be longer than non-deduplicated.\n\
+             Dedup len={}, No-dedup len={}",
+            schema_dedup.len(),
+            schema_no_dedup.len()
+        );
+    }
+
+    #[test]
+    fn test_special_characters_in_principal_and_resource_ids() {
+        // Ensures that special characters in entity IDs are properly
+        // escaped/quoted without panicking or producing malformed output.
+        let tools = r#"[
+            {
+                "name": "read_file",
+                "description": "Read a file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } },
+                    "required": ["path"]
+                }
+            }
+        ]"#;
+        let input = r#"{"params": {"tool": "read_file", "args": {"path": "/tmp"}}}"#;
+
+        // IDs with quotes, backslashes, unicode
+        let result_json = generate_request(
+            STUB,
+            tools,
+            input,
+            "User",
+            r#"alice "admin" O'Brien"#,
+            "McpServer",
+            "server/with\\special\nchars",
+            None,
+        );
+        let result: WasmRequestResult =
+            serde_json::from_str(&result_json).expect("Should parse result");
+        assert!(result.is_ok, "Error: {:?}", result.error);
+        // The principal and resource should contain the ID, properly escaped
+        assert!(result.principal.is_some());
+        assert!(result.resource.is_some());
     }
 }
 

--- a/rust/cedar-policy-mcp-schema-generator-wasm/src/lib.rs
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/src/lib.rs
@@ -923,12 +923,14 @@ mod coverage_tests {
         ]"#;
 
         // Without deduplication: both tool namespaces get their own entity type.
-        let result_no_dedup = generate_schema_inner(STUB, tools, Some(r#"{"deduplicateEntityTypes": false}"#));
+        let result_no_dedup =
+            generate_schema_inner(STUB, tools, Some(r#"{"deduplicateEntityTypes": false}"#));
         assert!(result_no_dedup.is_ok);
         let schema_no_dedup = result_no_dedup.schema.unwrap();
 
         // With deduplication: the enum should be deduplicated.
-        let result_dedup = generate_schema_inner(STUB, tools, Some(r#"{"deduplicateEntityTypes": true}"#));
+        let result_dedup =
+            generate_schema_inner(STUB, tools, Some(r#"{"deduplicateEntityTypes": true}"#));
         assert!(result_dedup.is_ok, "Error: {:?}", result_dedup.error);
         let schema_dedup = result_dedup.schema.unwrap();
 

--- a/rust/cedar-policy-mcp-schema-generator-wasm/tests/wasm_integration.rs
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/tests/wasm_integration.rs
@@ -16,18 +16,22 @@
 
 //! WASM integration tests for the Cedar MCP Schema Generator bindings.
 //!
-//! These tests exercise the `generateSchema` function through wasm-bindgen,
-//! verifying correct behavior at the JS/WASM boundary.
+//! These tests exercise `generateSchema` and `generateRequest` through
+//! wasm-bindgen, verifying correct behavior at the JS/WASM boundary.
 
-use cedar_policy_mcp_schema_generator_wasm::generate_schema;
+#![expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test assertions"
+)]
+
+use cedar_policy_mcp_schema_generator_wasm::{generate_request, generate_schema};
 use wasm_bindgen_test::*;
 
-/// Helper: parse the JSON result and return the deserialized fields.
-fn parse_result(json: &str) -> serde_json::Value {
-    serde_json::from_str(json).expect("Result should be valid JSON")
-}
+// ─── Shared constants ───────────────────────────────────────────────────────
 
-/// Shared schema stub for tests.
+/// Minimal schema stub used across most tests.
 const STUB: &str = r#"
     namespace TestServer {
         @mcp_principal
@@ -41,46 +45,84 @@ const STUB: &str = r#"
     }
 "#;
 
+/// A single-tool description (string-typed input) reused across tests.
+const SINGLE_TOOL: &str = r#"[{
+    "name": "read_file",
+    "description": "Read a file from disk",
+    "inputSchema": {
+        "type": "object",
+        "properties": { "path": { "type": "string" } },
+        "required": ["path"]
+    }
+}]"#;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/// Parse a JSON result string into a `serde_json::Value`.
+fn parse_result(json: &str) -> serde_json::Value {
+    serde_json::from_str(json).expect("Result should be valid JSON")
+}
+
+/// Assert a schema result succeeded and return the schema text.
+fn assert_schema_ok(result: &serde_json::Value) -> &str {
+    assert_eq!(result["isOk"], true, "Error: {:?}", result["error"]);
+    assert!(result["error"].is_null());
+    result["schema"]
+        .as_str()
+        .expect("schema should be a string")
+}
+
+/// Assert a schema result failed and return the error message.
+fn assert_schema_err(result: &serde_json::Value) -> &str {
+    assert_eq!(result["isOk"], false);
+    assert!(result["schema"].is_null());
+    result["error"]
+        .as_str()
+        .expect("error should be a string")
+}
+
+/// Assert a request result succeeded and return the parsed value.
+fn assert_request_ok(result: &serde_json::Value) {
+    assert_eq!(result["isOk"], true, "Error: {:?}", result["error"]);
+    assert!(result["error"].is_null());
+    assert!(!result["principal"].is_null());
+    assert!(!result["action"].is_null());
+    assert!(!result["resource"].is_null());
+    assert!(!result["entitiesJson"].is_null());
+}
+
+/// Assert a request result failed and return the error message.
+fn assert_request_err(result: &serde_json::Value) -> &str {
+    assert_eq!(result["isOk"], false);
+    assert!(result["principal"].is_null());
+    assert!(result["action"].is_null());
+    assert!(result["resource"].is_null());
+    assert!(result["entitiesJson"].is_null());
+    result["error"]
+        .as_str()
+        .expect("error should be a string")
+}
+
+/// Build an MCP tool call input JSON string for a given tool name and args object.
+fn tool_input(tool_name: &str, args_json: &str) -> String {
+    format!(r#"{{"params": {{"tool": "{tool_name}", "args": {args_json}}}}}"#)
+}
+
+// ─── Schema generation tests ────────────────────────────────────────────────
+
 #[wasm_bindgen_test]
 fn test_basic_schema_generation() {
-    let tools = r#"[
-        {
-            "name": "read_file",
-            "description": "Read a file from disk",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "path": { "type": "string" }
-                },
-                "required": ["path"]
-            }
-        }
-    ]"#;
+    let result = parse_result(&generate_schema(STUB, SINGLE_TOOL, None));
+    let schema = assert_schema_ok(&result);
 
-    let result_json = generate_schema(STUB, tools, None);
-    let result = parse_result(&result_json);
+    assert!(schema.contains("read_file"));
+    assert!(schema.contains("read_fileInput"));
+    assert!(schema.contains("String"));
 
-    assert_eq!(result["isOk"], true);
-    assert!(result["error"].is_null());
-
-    let schema = result["schema"].as_str().unwrap();
-    assert!(
-        schema.contains("read_file"),
-        "Schema should contain read_file action"
-    );
-    assert!(
-        schema.contains("read_fileInput"),
-        "Schema should contain input type"
-    );
-    assert!(
-        schema.contains("String"),
-        "Schema should contain String type for path"
-    );
-
-    // schemaJson should also be present and valid JSON
+    // schemaJson should be valid JSON
     let schema_json_str = result["schemaJson"].as_str().unwrap();
-    let _schema_json: serde_json::Value =
-        serde_json::from_str(schema_json_str).expect("schemaJson should be valid JSON");
+    serde_json::from_str::<serde_json::Value>(schema_json_str)
+        .expect("schemaJson should be valid JSON");
 }
 
 #[wasm_bindgen_test]
@@ -103,118 +145,430 @@ fn test_multi_tool_schema() {
             "description": "Read a file",
             "inputSchema": {
                 "type": "object",
-                "properties": {
-                    "path": { "type": "string" }
-                },
+                "properties": { "path": { "type": "string" } },
                 "required": ["path"]
             }
         }
     ]"#;
 
-    let result_json = generate_schema(STUB, tools, None);
-    let result = parse_result(&result_json);
+    let result = parse_result(&generate_schema(STUB, tools, None));
+    let schema = assert_schema_ok(&result);
 
-    assert_eq!(result["isOk"], true);
-    let schema = result["schema"].as_str().unwrap();
-    assert!(
-        schema.contains("execute_command"),
-        "Should contain execute_command"
-    );
-    assert!(schema.contains("read_file"), "Should contain read_file");
-    assert!(
-        schema.contains("Long"),
-        "Integer should map to Long by default"
-    );
+    assert!(schema.contains("execute_command"));
+    assert!(schema.contains("read_file"));
+    assert!(schema.contains("Long"), "integer should map to Long");
 }
 
 #[wasm_bindgen_test]
 fn test_config_numbers_as_decimal() {
+    let tools = r#"[{
+        "name": "calculate",
+        "description": "Calculate",
+        "inputSchema": {
+            "type": "object",
+            "properties": { "value": { "type": "number" } },
+            "required": ["value"]
+        }
+    }]"#;
+
+    let result = parse_result(&generate_schema(
+        STUB,
+        tools,
+        Some(r#"{"numbersAsDecimal": true}"#.to_string()),
+    ));
+    let schema = assert_schema_ok(&result);
+    assert!(schema.contains("Decimal"));
+}
+
+#[wasm_bindgen_test]
+fn test_config_objects_as_records() {
+    let tools = r#"[{
+        "name": "create",
+        "description": "Create item",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "meta": {
+                    "type": "object",
+                    "properties": { "key": { "type": "string" } },
+                    "required": ["key"]
+                }
+            }
+        }
+    }]"#;
+
+    let without = parse_result(&generate_schema(STUB, tools, None));
+    let with = parse_result(&generate_schema(
+        STUB,
+        tools,
+        Some(r#"{"objectsAsRecords": true}"#.to_string()),
+    ));
+
+    assert_schema_ok(&without);
+    assert_schema_ok(&with);
+    // objectsAsRecords changes representation; schemas should differ
+    assert_ne!(without["schema"], with["schema"]);
+}
+
+#[wasm_bindgen_test]
+fn test_config_flatten_namespaces() {
+    let tools = r#"[{
+        "name": "do_thing",
+        "description": "Do",
+        "inputSchema": {
+            "type": "object",
+            "properties": { "x": { "type": "string" } }
+        }
+    }]"#;
+
+    let result = parse_result(&generate_schema(
+        STUB,
+        tools,
+        Some(r#"{"flattenNamespaces": true}"#.to_string()),
+    ));
+    assert_schema_ok(&result);
+}
+
+#[wasm_bindgen_test]
+fn test_config_deduplicate_entity_types() {
+    // Two tools with identical enums; deduplication should consolidate them.
     let tools = r#"[
         {
-            "name": "calculate",
-            "description": "Calculate something",
+            "name": "tool_a",
+            "description": "A",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "value": { "type": "number" }
-                },
-                "required": ["value"]
+                    "status": { "type": "string", "enum": ["on", "off"] }
+                }
+            }
+        },
+        {
+            "name": "tool_b",
+            "description": "B",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "status": { "type": "string", "enum": ["on", "off"] }
+                }
             }
         }
     ]"#;
 
-    let config = r#"{"numbersAsDecimal": true}"#;
-    let result_json = generate_schema(STUB, tools, Some(config.to_string()));
-    let result = parse_result(&result_json);
+    let without = parse_result(&generate_schema(STUB, tools, None));
+    let with = parse_result(&generate_schema(
+        STUB,
+        tools,
+        Some(r#"{"deduplicateEntityTypes": true}"#.to_string()),
+    ));
 
-    assert_eq!(result["isOk"], true);
-    let schema = result["schema"].as_str().unwrap();
+    let schema_without = assert_schema_ok(&without);
+    let schema_with = assert_schema_ok(&with);
+
+    // Deduplicated schema should be shorter or equal (fewer entity types).
+    assert!(schema_with.len() <= schema_without.len());
+}
+
+#[wasm_bindgen_test]
+fn test_config_erase_annotations_false() {
+    let result = parse_result(&generate_schema(
+        STUB,
+        SINGLE_TOOL,
+        Some(r#"{"eraseAnnotations": false}"#.to_string()),
+    ));
+    let schema = assert_schema_ok(&result);
     assert!(
-        schema.contains("Decimal"),
-        "With numbersAsDecimal, number types should map to Decimal"
+        schema.contains("mcp_principal"),
+        "Annotations should be preserved"
     );
 }
 
 #[wasm_bindgen_test]
-fn test_invalid_schema_stub_returns_error() {
-    let result_json = generate_schema("this is not valid cedar schema", "[]", None);
-    let result = parse_result(&result_json);
-
-    assert_eq!(result["isOk"], false);
-    assert!(!result["error"].is_null(), "Should have an error message");
-    assert!(result["schema"].is_null(), "Schema should be null on error");
-}
-
-#[wasm_bindgen_test]
-fn test_invalid_tools_json_returns_error() {
-    let result_json = generate_schema(STUB, "not valid json", None);
-    let result = parse_result(&result_json);
-
-    assert_eq!(result["isOk"], false);
-    assert!(!result["error"].is_null());
-}
-
-#[wasm_bindgen_test]
-fn test_invalid_config_returns_error() {
-    let tools =
-        r#"[{"name":"t","description":"d","inputSchema":{"type":"object","properties":{}}}]"#;
-    let result_json = generate_schema(STUB, tools, Some("not valid json".to_string()));
-    let result = parse_result(&result_json);
-
-    assert_eq!(result["isOk"], false);
-    assert!(result["error"].as_str().unwrap().contains("Invalid config"),);
+fn test_config_erase_annotations_true_is_default() {
+    let result = parse_result(&generate_schema(STUB, SINGLE_TOOL, None));
+    let schema = assert_schema_ok(&result);
+    assert!(
+        !schema.contains("mcp_principal"),
+        "Annotations should be erased by default"
+    );
 }
 
 #[wasm_bindgen_test]
 fn test_empty_tools_produces_minimal_schema() {
-    let result_json = generate_schema(STUB, "[]", None);
-    let result = parse_result(&result_json);
-
-    assert_eq!(result["isOk"], true);
-    let schema = result["schema"].as_str().unwrap();
-    assert!(
-        schema.contains("TestServer"),
-        "Should contain the namespace"
-    );
-    assert!(
-        schema.contains("call_tool"),
-        "Should contain the base action"
-    );
+    let result = parse_result(&generate_schema(STUB, "[]", None));
+    let schema = assert_schema_ok(&result);
+    assert!(schema.contains("TestServer"));
+    assert!(schema.contains("call_tool"));
 }
 
 #[wasm_bindgen_test]
 fn test_optional_config_defaults() {
-    // Passing None for config should use defaults (same as empty config)
-    let tools = r#"[{"name":"t","description":"d","inputSchema":{"type":"object","properties":{"x":{"type":"string"}}}}]"#;
+    let r1 = parse_result(&generate_schema(STUB, SINGLE_TOOL, None));
+    let r2 = parse_result(&generate_schema(
+        STUB,
+        SINGLE_TOOL,
+        Some("{}".to_string()),
+    ));
 
-    let result_none = generate_schema(STUB, tools, None);
-    let result_empty = generate_schema(STUB, tools, Some("{}".to_string()));
-
-    let r1 = parse_result(&result_none);
-    let r2 = parse_result(&result_empty);
-
-    assert_eq!(r1["isOk"], true);
-    assert_eq!(r2["isOk"], true);
-    // Both should produce the same schema
+    assert_schema_ok(&r1);
+    assert_schema_ok(&r2);
     assert_eq!(r1["schema"], r2["schema"]);
+}
+
+// ─── Schema generation error tests ─────────────────────────────────────────
+
+#[wasm_bindgen_test]
+fn test_invalid_schema_stub_returns_error() {
+    let result = parse_result(&generate_schema("not valid cedar schema", "[]", None));
+    let error = assert_schema_err(&result);
+    assert!(error.contains("Schema error"));
+}
+
+#[wasm_bindgen_test]
+fn test_invalid_tools_json_returns_error() {
+    let result = parse_result(&generate_schema(STUB, "not valid json", None));
+    let error = assert_schema_err(&result);
+    assert!(error.contains("Invalid tool descriptions"));
+}
+
+#[wasm_bindgen_test]
+fn test_invalid_config_returns_error() {
+    let result = parse_result(&generate_schema(
+        STUB,
+        SINGLE_TOOL,
+        Some("not valid json".to_string()),
+    ));
+    let error = assert_schema_err(&result);
+    assert!(error.contains("Invalid config"));
+}
+
+#[wasm_bindgen_test]
+fn test_unknown_config_field_returns_error() {
+    let result = parse_result(&generate_schema(
+        STUB,
+        SINGLE_TOOL,
+        Some(r#"{"typoField": true}"#.to_string()),
+    ));
+    let error = assert_schema_err(&result);
+    assert!(error.contains("Invalid config"));
+}
+
+// ─── Request generation tests ───────────────────────────────────────────────
+
+#[wasm_bindgen_test]
+fn test_generate_request_basic() {
+    let input = tool_input("read_file", r#"{"path": "/tmp/test.txt"}"#);
+    let result = parse_result(&generate_request(
+        STUB, SINGLE_TOOL, &input, "User", "alice", "McpServer", "s1", None,
+    ));
+
+    assert_request_ok(&result);
+    assert!(result["principal"].as_str().unwrap().contains("User"));
+    assert!(result["principal"].as_str().unwrap().contains("alice"));
+    assert!(result["action"].as_str().unwrap().contains("read_file"));
+    assert!(result["resource"].as_str().unwrap().contains("McpServer"));
+    assert!(result["resource"].as_str().unwrap().contains("s1"));
+
+    // entities_json should be a valid JSON array
+    let entities: serde_json::Value =
+        serde_json::from_str(result["entitiesJson"].as_str().unwrap()).unwrap();
+    assert!(entities.is_array());
+}
+
+#[wasm_bindgen_test]
+fn test_generate_request_multi_tool_selects_correct_action() {
+    let tools = r#"[
+        {
+            "name": "read_file",
+            "description": "Read",
+            "inputSchema": {
+                "type": "object",
+                "properties": { "path": { "type": "string" } },
+                "required": ["path"]
+            }
+        },
+        {
+            "name": "write_file",
+            "description": "Write",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string" },
+                    "content": { "type": "string" }
+                },
+                "required": ["path", "content"]
+            }
+        }
+    ]"#;
+
+    let input = tool_input("write_file", r#"{"path": "/out", "content": "hi"}"#);
+    let result = parse_result(&generate_request(
+        STUB, tools, &input, "User", "bob", "McpServer", "prod", None,
+    ));
+
+    assert_request_ok(&result);
+    assert!(result["action"].as_str().unwrap().contains("write_file"));
+    assert!(!result["action"].as_str().unwrap().contains("read_file"));
+}
+
+#[wasm_bindgen_test]
+fn test_generate_request_with_nested_object_produces_entities() {
+    let tools = r#"[{
+        "name": "ingest",
+        "description": "Ingest",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "source": { "type": "string" }
+                    },
+                    "required": ["source"]
+                }
+            },
+            "required": ["metadata"]
+        }
+    }]"#;
+
+    let input = tool_input("ingest", r#"{"metadata": {"source": "sensor-1"}}"#);
+    let result = parse_result(&generate_request(
+        STUB, tools, &input, "User", "alice", "McpServer", "s1", None,
+    ));
+
+    assert_request_ok(&result);
+    let entities: serde_json::Value =
+        serde_json::from_str(result["entitiesJson"].as_str().unwrap()).unwrap();
+    let arr = entities.as_array().unwrap();
+    assert!(
+        !arr.is_empty(),
+        "Nested objects should produce entities"
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_generate_request_with_config() {
+    let tools = r#"[{
+        "name": "calc",
+        "description": "Calculate",
+        "inputSchema": {
+            "type": "object",
+            "properties": { "value": { "type": "number" } },
+            "required": ["value"]
+        }
+    }]"#;
+
+    let input = tool_input("calc", r#"{"value": 3.14}"#);
+    let result = parse_result(&generate_request(
+        STUB, tools, &input, "User", "alice", "McpServer", "s1",
+        Some(r#"{"numbersAsDecimal": true}"#.to_string()),
+    ));
+    assert_request_ok(&result);
+}
+
+#[wasm_bindgen_test]
+fn test_generate_request_empty_config_uses_defaults() {
+    let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
+    let result = parse_result(&generate_request(
+        STUB, SINGLE_TOOL, &input, "User", "u", "McpServer", "s", Some(String::new()),
+    ));
+    assert_request_ok(&result);
+}
+
+// ─── Request generation error tests ────────────────────────────────────────
+
+#[wasm_bindgen_test]
+fn test_generate_request_invalid_input_returns_error() {
+    let result = parse_result(&generate_request(
+        STUB, SINGLE_TOOL, "not json", "User", "u1", "McpServer", "s1", None,
+    ));
+    let error = assert_request_err(&result);
+    assert!(error.contains("Invalid tool input"));
+}
+
+#[wasm_bindgen_test]
+fn test_generate_request_invalid_stub_returns_error() {
+    let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
+    let result = parse_result(&generate_request(
+        "bad stub", SINGLE_TOOL, &input, "User", "u", "McpServer", "s", None,
+    ));
+    let error = assert_request_err(&result);
+    assert!(error.contains("Schema error"));
+}
+
+#[wasm_bindgen_test]
+fn test_generate_request_invalid_tools_returns_error() {
+    let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
+    let result = parse_result(&generate_request(
+        STUB, "bad json", &input, "User", "u", "McpServer", "s", None,
+    ));
+    let error = assert_request_err(&result);
+    assert!(error.contains("Invalid tool descriptions"));
+}
+
+#[wasm_bindgen_test]
+fn test_generate_request_invalid_config_returns_error() {
+    let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
+    let result = parse_result(&generate_request(
+        STUB, SINGLE_TOOL, &input, "User", "u", "McpServer", "s",
+        Some("bad json".to_string()),
+    ));
+    let error = assert_request_err(&result);
+    assert!(error.contains("Invalid config"));
+}
+
+#[wasm_bindgen_test]
+fn test_generate_request_unknown_config_field_returns_error() {
+    let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
+    let result = parse_result(&generate_request(
+        STUB, SINGLE_TOOL, &input, "User", "u", "McpServer", "s",
+        Some(r#"{"badField": true}"#.to_string()),
+    ));
+    let error = assert_request_err(&result);
+    assert!(error.contains("Invalid config"));
+}
+
+// ─── Consistency tests ──────────────────────────────────────────────────────
+
+#[wasm_bindgen_test]
+fn test_schema_and_request_use_same_namespace() {
+    let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
+
+    let schema_result = parse_result(&generate_schema(STUB, SINGLE_TOOL, None));
+    let schema = assert_schema_ok(&schema_result);
+
+    let req_result = parse_result(&generate_request(
+        STUB, SINGLE_TOOL, &input, "User", "alice", "McpServer", "s1", None,
+    ));
+    assert_request_ok(&req_result);
+
+    // Both should reference the same namespace
+    assert!(schema.contains("TestServer"));
+    assert!(req_result["principal"]
+        .as_str()
+        .unwrap()
+        .contains("TestServer"));
+    assert!(req_result["action"]
+        .as_str()
+        .unwrap()
+        .contains("TestServer"));
+    assert!(req_result["resource"]
+        .as_str()
+        .unwrap()
+        .contains("TestServer"));
+}
+
+#[wasm_bindgen_test]
+fn test_schema_json_is_parseable_and_contains_actions() {
+    let result = parse_result(&generate_schema(STUB, SINGLE_TOOL, None));
+    assert_schema_ok(&result);
+
+    let schema_json: serde_json::Value =
+        serde_json::from_str(result["schemaJson"].as_str().unwrap()).unwrap();
+
+    // The JSON schema should be an object with namespace keys
+    assert!(schema_json.is_object());
+    // Should contain at least one namespace with actions
+    let ns = schema_json.as_object().unwrap();
+    assert!(!ns.is_empty(), "schemaJson should have namespace entries");
 }

--- a/rust/cedar-policy-mcp-schema-generator-wasm/tests/wasm_integration.rs
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/tests/wasm_integration.rs
@@ -76,9 +76,7 @@ fn assert_schema_ok(result: &serde_json::Value) -> &str {
 fn assert_schema_err(result: &serde_json::Value) -> &str {
     assert_eq!(result["isOk"], false);
     assert!(result["schema"].is_null());
-    result["error"]
-        .as_str()
-        .expect("error should be a string")
+    result["error"].as_str().expect("error should be a string")
 }
 
 /// Assert a request result succeeded and return the parsed value.
@@ -98,9 +96,7 @@ fn assert_request_err(result: &serde_json::Value) -> &str {
     assert!(result["action"].is_null());
     assert!(result["resource"].is_null());
     assert!(result["entitiesJson"].is_null());
-    result["error"]
-        .as_str()
-        .expect("error should be a string")
+    result["error"].as_str().expect("error should be a string")
 }
 
 /// Build an MCP tool call input JSON string for a given tool name and args object.
@@ -304,11 +300,7 @@ fn test_empty_tools_produces_minimal_schema() {
 #[wasm_bindgen_test]
 fn test_optional_config_defaults() {
     let r1 = parse_result(&generate_schema(STUB, SINGLE_TOOL, None));
-    let r2 = parse_result(&generate_schema(
-        STUB,
-        SINGLE_TOOL,
-        Some("{}".to_string()),
-    ));
+    let r2 = parse_result(&generate_schema(STUB, SINGLE_TOOL, Some("{}".to_string())));
 
     assert_schema_ok(&r1);
     assert_schema_ok(&r2);
@@ -359,7 +351,14 @@ fn test_unknown_config_field_returns_error() {
 fn test_generate_request_basic() {
     let input = tool_input("read_file", r#"{"path": "/tmp/test.txt"}"#);
     let result = parse_result(&generate_request(
-        STUB, SINGLE_TOOL, &input, "User", "alice", "McpServer", "s1", None,
+        STUB,
+        SINGLE_TOOL,
+        &input,
+        "User",
+        "alice",
+        "McpServer",
+        "s1",
+        None,
     ));
 
     assert_request_ok(&result);
@@ -403,7 +402,14 @@ fn test_generate_request_multi_tool_selects_correct_action() {
 
     let input = tool_input("write_file", r#"{"path": "/out", "content": "hi"}"#);
     let result = parse_result(&generate_request(
-        STUB, tools, &input, "User", "bob", "McpServer", "prod", None,
+        STUB,
+        tools,
+        &input,
+        "User",
+        "bob",
+        "McpServer",
+        "prod",
+        None,
     ));
 
     assert_request_ok(&result);
@@ -433,17 +439,21 @@ fn test_generate_request_with_nested_object_produces_entities() {
 
     let input = tool_input("ingest", r#"{"metadata": {"source": "sensor-1"}}"#);
     let result = parse_result(&generate_request(
-        STUB, tools, &input, "User", "alice", "McpServer", "s1", None,
+        STUB,
+        tools,
+        &input,
+        "User",
+        "alice",
+        "McpServer",
+        "s1",
+        None,
     ));
 
     assert_request_ok(&result);
     let entities: serde_json::Value =
         serde_json::from_str(result["entitiesJson"].as_str().unwrap()).unwrap();
     let arr = entities.as_array().unwrap();
-    assert!(
-        !arr.is_empty(),
-        "Nested objects should produce entities"
-    );
+    assert!(!arr.is_empty(), "Nested objects should produce entities");
 }
 
 #[wasm_bindgen_test]
@@ -460,7 +470,13 @@ fn test_generate_request_with_config() {
 
     let input = tool_input("calc", r#"{"value": 3.14}"#);
     let result = parse_result(&generate_request(
-        STUB, tools, &input, "User", "alice", "McpServer", "s1",
+        STUB,
+        tools,
+        &input,
+        "User",
+        "alice",
+        "McpServer",
+        "s1",
         Some(r#"{"numbersAsDecimal": true}"#.to_string()),
     ));
     assert_request_ok(&result);
@@ -470,7 +486,14 @@ fn test_generate_request_with_config() {
 fn test_generate_request_empty_config_uses_defaults() {
     let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
     let result = parse_result(&generate_request(
-        STUB, SINGLE_TOOL, &input, "User", "u", "McpServer", "s", Some(String::new()),
+        STUB,
+        SINGLE_TOOL,
+        &input,
+        "User",
+        "u",
+        "McpServer",
+        "s",
+        Some(String::new()),
     ));
     assert_request_ok(&result);
 }
@@ -480,7 +503,14 @@ fn test_generate_request_empty_config_uses_defaults() {
 #[wasm_bindgen_test]
 fn test_generate_request_invalid_input_returns_error() {
     let result = parse_result(&generate_request(
-        STUB, SINGLE_TOOL, "not json", "User", "u1", "McpServer", "s1", None,
+        STUB,
+        SINGLE_TOOL,
+        "not json",
+        "User",
+        "u1",
+        "McpServer",
+        "s1",
+        None,
     ));
     let error = assert_request_err(&result);
     assert!(error.contains("Invalid tool input"));
@@ -490,7 +520,14 @@ fn test_generate_request_invalid_input_returns_error() {
 fn test_generate_request_invalid_stub_returns_error() {
     let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
     let result = parse_result(&generate_request(
-        "bad stub", SINGLE_TOOL, &input, "User", "u", "McpServer", "s", None,
+        "bad stub",
+        SINGLE_TOOL,
+        &input,
+        "User",
+        "u",
+        "McpServer",
+        "s",
+        None,
     ));
     let error = assert_request_err(&result);
     assert!(error.contains("Schema error"));
@@ -500,7 +537,14 @@ fn test_generate_request_invalid_stub_returns_error() {
 fn test_generate_request_invalid_tools_returns_error() {
     let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
     let result = parse_result(&generate_request(
-        STUB, "bad json", &input, "User", "u", "McpServer", "s", None,
+        STUB,
+        "bad json",
+        &input,
+        "User",
+        "u",
+        "McpServer",
+        "s",
+        None,
     ));
     let error = assert_request_err(&result);
     assert!(error.contains("Invalid tool descriptions"));
@@ -510,7 +554,13 @@ fn test_generate_request_invalid_tools_returns_error() {
 fn test_generate_request_invalid_config_returns_error() {
     let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
     let result = parse_result(&generate_request(
-        STUB, SINGLE_TOOL, &input, "User", "u", "McpServer", "s",
+        STUB,
+        SINGLE_TOOL,
+        &input,
+        "User",
+        "u",
+        "McpServer",
+        "s",
         Some("bad json".to_string()),
     ));
     let error = assert_request_err(&result);
@@ -521,7 +571,13 @@ fn test_generate_request_invalid_config_returns_error() {
 fn test_generate_request_unknown_config_field_returns_error() {
     let input = tool_input("read_file", r#"{"path": "/tmp"}"#);
     let result = parse_result(&generate_request(
-        STUB, SINGLE_TOOL, &input, "User", "u", "McpServer", "s",
+        STUB,
+        SINGLE_TOOL,
+        &input,
+        "User",
+        "u",
+        "McpServer",
+        "s",
         Some(r#"{"badField": true}"#.to_string()),
     ));
     let error = assert_request_err(&result);
@@ -538,7 +594,14 @@ fn test_schema_and_request_use_same_namespace() {
     let schema = assert_schema_ok(&schema_result);
 
     let req_result = parse_result(&generate_request(
-        STUB, SINGLE_TOOL, &input, "User", "alice", "McpServer", "s1", None,
+        STUB,
+        SINGLE_TOOL,
+        &input,
+        "User",
+        "alice",
+        "McpServer",
+        "s1",
+        None,
     ));
     assert_request_ok(&req_result);
 


### PR DESCRIPTION
This PR contains several changes:
- refactors integration tests, and then adds integration tests for `generate_request`
- adds the new `deduplicate_entity_types` option of the schema generator crate,
- finally, documentation for the new option and the request generation functionality in the README.md
- some changes in dependencies features (Cargo.toml) to make `wasm-pack` work
This is yet to be released code.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.