### PR TITLE
amend repetitive information rewrite in package script + js wasm inte…

### DIFF
--- a/.github/scripts/prepare_wasm_npm_package.mjs
+++ b/.github/scripts/prepare_wasm_npm_package.mjs
@@ -18,48 +18,25 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const [pkgDirArg, cargoTomlArg] = process.argv.slice(2);
+const [pkgDirArg] = process.argv.slice(2);
 
-if (!pkgDirArg || !cargoTomlArg) {
+if (!pkgDirArg) {
   console.error(
-    "Usage: node .github/scripts/prepare_wasm_npm_package.mjs <pkg-dir> <Cargo.toml>",
+    "Usage: node .github/scripts/prepare_wasm_npm_package.mjs <pkg-dir>",
   );
   process.exit(1);
 }
 
 const pkgDir = path.resolve(pkgDirArg);
-const cargoTomlPath = path.resolve(cargoTomlArg);
 const packageJsonPath = path.join(pkgDir, "package.json");
 
-const cargoToml = fs.readFileSync(cargoTomlPath, "utf8");
-const versionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
-
-if (!versionMatch) {
-  console.error(`Could not find package.version in ${cargoTomlPath}`);
-  process.exit(1);
-}
-
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-const cargoVersion = versionMatch[1];
-const packageName = "@cedar-policy/mcp-schema-generator-wasm";
 
 // wasm-pack derives scoped package names from the Rust crate name. Since this
 // crate already carries the repository prefix, the derived scoped name would be
 // @cedar-policy/cedar-policy-mcp-schema-generator-wasm. Normalize it to the
 // shorter package name documented for JavaScript consumers.
-packageJson.name = packageName;
-packageJson.version = cargoVersion;
-packageJson.description =
-  "WASM bindings for generating Cedar schemas and authorization requests from MCP tool descriptions.";
-packageJson.license = "Apache-2.0";
-packageJson.repository = {
-  type: "git",
-  url: "https://github.com/cedar-policy/cedar-for-agents.git",
-  directory: "rust/cedar-policy-mcp-schema-generator-wasm",
-};
-packageJson.homepage =
-  "https://github.com/cedar-policy/cedar-for-agents/tree/main/rust/cedar-policy-mcp-schema-generator-wasm";
-packageJson.keywords = ["cedar", "authorization", "agents", "mcp", "wasm"];
+packageJson.name = "@cedar-policy/mcp-schema-generator-wasm";
 packageJson.sideEffects = false;
 
 fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,6 @@ jobs:
 
   build_and_test_js:
     uses: ./.github/workflows/build_and_test_js.yml
+
+  wasm_integration_tests:
+    uses: ./.github/workflows/wasm_integration_tests.yml

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -18,3 +18,6 @@ jobs:
 
   build_and_test_js:
     uses: ./.github/workflows/build_and_test_js.yml
+
+  wasm_integration_tests:
+    uses: ./.github/workflows/wasm_integration_tests.yml

--- a/.github/workflows/publish_wasm_npm.yml
+++ b/.github/workflows/publish_wasm_npm.yml
@@ -132,7 +132,6 @@ jobs:
         run: >-
           node .github/scripts/prepare_wasm_npm_package.mjs
           rust/cedar-policy-mcp-schema-generator-wasm/pkg
-          rust/cedar-policy-mcp-schema-generator-wasm/Cargo.toml
 
       - name: Validate npm package contents
         run: npm pack --dry-run

--- a/.github/workflows/wasm_integration_tests.yml
+++ b/.github/workflows/wasm_integration_tests.yml
@@ -1,0 +1,31 @@
+name: WASM Integration Tests
+on:
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  wasm_node_tests:
+    name: WASM Node.js Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure Rust toolchain
+        run: rustup update stable && rustup default stable
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Build WASM package
+        run: wasm-pack build . --target nodejs --out-dir pkg
+        working-directory: rust/cedar-policy-mcp-schema-generator-wasm
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "lts/*"
+
+      - name: Run Node.js integration tests
+        run: node --test test.mjs
+        working-directory: rust/cedar-policy-mcp-schema-generator-wasm/tests/node

--- a/.github/workflows/wasm_integration_tests.yml
+++ b/.github/workflows/wasm_integration_tests.yml
@@ -18,8 +18,19 @@ jobs:
         run: cargo install wasm-pack --locked
 
       - name: Build WASM package
-        run: wasm-pack build . --target nodejs --out-dir pkg
+        # Keep flags in sync with publish_wasm_npm.yml
+        run: >-
+          wasm-pack build .
+          --target nodejs
+          --scope cedar-policy
+          --out-dir pkg
         working-directory: rust/cedar-policy-mcp-schema-generator-wasm
+
+      - name: Normalize npm package metadata
+        # We test the package naming in CI, it needs to mirror publish_wasm_npm.yml
+        run: >-
+          node .github/scripts/prepare_wasm_npm_package.mjs
+          rust/cedar-policy-mcp-schema-generator-wasm/pkg
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/rust/cedar-policy-mcp-schema-generator-wasm/tests/node/package.json
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/tests/node/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wasm-integration-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test.mjs"
+  }
+}

--- a/rust/cedar-policy-mcp-schema-generator-wasm/tests/node/test.mjs
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/tests/node/test.mjs
@@ -1,0 +1,92 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Integration tests exercising the WASM package from Node.js.
+// Requires `wasm-pack build --target nodejs` to have been run first.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateSchema, generateRequest } from "../../pkg/cedar_policy_mcp_schema_generator_wasm.js";
+
+const STUB = `
+  namespace TestServer {
+    @mcp_principal
+    entity User;
+    @mcp_resource
+    entity McpServer;
+    action "call_tool" appliesTo {
+      principal: [User],
+      resource: [McpServer]
+    };
+  }
+`;
+
+const TOOLS = JSON.stringify([
+  {
+    name: "read_file",
+    description: "Read a file from disk",
+    inputSchema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+  },
+]);
+
+describe("generateSchema", () => {
+  it("produces a valid schema from a stub and tool descriptions", () => {
+    const result = JSON.parse(generateSchema(STUB, TOOLS));
+    assert.equal(result.isOk, true, `Expected success, got error: ${result.error}`);
+    assert.ok(result.schema.length > 0, "Schema should not be empty");
+    assert.ok(result.schemaJson.length > 0, "Schema JSON should not be empty");
+    assert.ok(result.schema.includes("read_file"), "Schema should reference the tool");
+  });
+
+  it("returns an error for an invalid stub", () => {
+    const result = JSON.parse(generateSchema("not valid cedar", TOOLS));
+    assert.equal(result.isOk, false);
+    assert.ok(result.error.length > 0);
+  });
+});
+
+describe("generateRequest", () => {
+  it("produces an authorization request for a tool call", () => {
+    const input = JSON.stringify({
+      params: { tool: "read_file", args: { path: "/etc/hosts" } },
+    });
+
+    const result = JSON.parse(
+      generateRequest(STUB, TOOLS, input, "User", "alice", "McpServer", "my-server"),
+    );
+    assert.equal(result.isOk, true, `Expected success, got error: ${result.error}`);
+    assert.ok(result.principal.includes("alice"), "Principal should reference alice");
+    assert.ok(result.action.includes("read_file"), "Action should reference the tool");
+    assert.ok(result.resource.includes("my-server"), "Resource should reference the server");
+    assert.ok(result.entitiesJson.length > 0, "Entities JSON should not be empty");
+  });
+
+  it("returns an error for a non-existent tool", () => {
+    const input = JSON.stringify({
+      params: { tool: "no_such_tool", args: {} },
+    });
+
+    const result = JSON.parse(
+      generateRequest(STUB, TOOLS, input, "User", "alice", "McpServer", "my-server"),
+    );
+    assert.equal(result.isOk, false);
+    assert.ok(result.error.length > 0);
+  });
+});

--- a/rust/cedar-policy-mcp-schema-generator-wasm/tests/node/test.mjs
+++ b/rust/cedar-policy-mcp-schema-generator-wasm/tests/node/test.mjs
@@ -19,6 +19,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { generateSchema, generateRequest } from "../../pkg/cedar_policy_mcp_schema_generator_wasm.js";
 
 const STUB = `
@@ -88,5 +89,13 @@ describe("generateRequest", () => {
     );
     assert.equal(result.isOk, false);
     assert.ok(result.error.length > 0);
+  });
+});
+
+describe("package metadata", () => {
+  it("has the correct normalized package name and sideEffects flag", () => {
+    const pkg = JSON.parse(readFileSync(new URL("../../pkg/package.json", import.meta.url), "utf8"));
+    assert.equal(pkg.name, "@cedar-policy/mcp-schema-generator-wasm");
+    assert.equal(pkg.sideEffects, false);
   });
 });


### PR DESCRIPTION
- Fixes the JS package-renaming script to not repeat information following @katherine-hough 's comments
- Adds an smoke test for the wasm bindings from a JS file (trivial functionality + naming).

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to non public-facing "internal" APIs)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.