### PR TITLE
feat(builder): add cedar builder in js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 rust/Cargo.lock
 rust/*/Cargo.lock
 rust/target/
+js/*/dist/
+js/*/node_modules

--- a/js/cedar-agent-policy-builder/CHANGELOG.md
+++ b/js/cedar-agent-policy-builder/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial release of `cedar-agent-policy-builder`
+- Fluent builder API: `.role()`, `.restrict()`, `.rateLimit()`, `.timeWindow()`, `.denyToolsInEnv()`, `.consent()`, `.resource()`, `.namespace()`, `.tools()`
+- `fromConfig()` function for JSON/object-based configuration
+- Cedar schema generation via `@cedar-policy/mcp-schema-generator-wasm` integration
+- McpServer resource entity generation (aligns with MCP schema generator conventions)
+- Consent-gated policies (permit when `context.session.user_consent == true`)
+- Build-time warnings for undeclared tool name references
+- Edge case handling: empty `allowedValues` = deny tool, `denyToolsInEnv()` without tools = deny all, `rateLimit(0)` = always deny

--- a/js/cedar-agent-policy-builder/README.md
+++ b/js/cedar-agent-policy-builder/README.md
@@ -22,6 +22,9 @@ const { policies, entities, schema } = new CedarAgentPolicyBuilder({
   // Policy configuration — defines who can do what
   .role('admin', ['*'])
   .role('analyst', ['search', 'query_database'])
+  .role('developer', ['delete_record'])
+  .user('alice', 'admin')
+  .user('bob', 'analyst', 'developer')
   .restrict('query_database', { allowedValues: { database: ['analytics', 'reporting'] } })
   .rateLimit('send_email', 3)
   .timeWindow({ hourStart: 9, hourEnd: 17 })
@@ -29,6 +32,7 @@ const { policies, entities, schema } = new CedarAgentPolicyBuilder({
   .consent(['send_email', 'delete_file'])
   .build()
 ```
+The policy configuration above references three roles 'admin', 'analyst' and 'developer', and attaches permissions to those roles. A user can have zero or more roles (.e.g. 'alice' is an 'admin' and 'bob' is an 'analyst' and a 'developer'). Declaring users is optional — if you omit `.user()` calls, the generated entities contain only roles and the resource, and you can resolve the principal directly as a `Role` entity (e.g. `{ type: 'Agent::Role', id: 'admin' }`) in your [Strands `principalResolver`](https://strandsagents.com/docs/user-guide/concepts/agents/interventions/cedar-authorization/). This works because Cedar's `in` operator treats an entity as being `in` itself, so `Role::"admin" in Role::"admin"` evaluates to true. When you do declare users, `build()` emits `User` entities with `Role` parents in the entity hierarchy, and your `principalResolver` returns the user identity for a full audit trail.
 
 <details>
 <summary><strong>Generated output</strong></summary>
@@ -39,22 +43,16 @@ The above produces:
 
 ```cedar
 permit(
-  principal is Agent::User,
+  principal in Agent::Role::"admin",
   action,
   resource
-) when { principal.role == "admin" };
+) when { !(action == Agent::Action::"send_email" || action == Agent::Action::"delete_file") };
 
-permit(
-  principal is Agent::User,
-  action == Agent::Action::"search",
-  resource
-) when { principal.role == "analyst" };
+permit(principal in Agent::Role::"analyst", action == Agent::Action::"search", resource);
 
-permit(
-  principal is Agent::User,
-  action == Agent::Action::"query_database",
-  resource
-) when { principal.role == "analyst" };
+permit(principal in Agent::Role::"analyst", action == Agent::Action::"query_database", resource);
+
+permit(principal in Agent::Role::"developer", action == Agent::Action::"delete_record", resource);
 
 forbid(
   principal,
@@ -83,13 +81,13 @@ forbid(
 ) when { context.session has "environment" && context.session.environment == "production" };
 
 permit(
-  principal is Agent::User,
+  principal,
   action == Agent::Action::"send_email",
   resource
 ) when { context.session has "user_consent" && context.session.user_consent == true };
 
 permit(
-  principal is Agent::User,
+  principal,
   action == Agent::Action::"delete_file",
   resource
 ) when { context.session has "user_consent" && context.session.user_consent == true };
@@ -99,9 +97,12 @@ permit(
 
 ```json
 [
-  { "uid": { "type": "Role", "id": "admin" }, "attrs": {}, "parents": [] },
-  { "uid": { "type": "Role", "id": "analyst" }, "attrs": {}, "parents": [] },
-  { "uid": { "type": "McpServer", "id": "default" }, "attrs": {}, "parents": [] }
+  { "uid": { "type": "Agent::Role", "id": "admin" }, "attrs": {}, "parents": [] },
+  { "uid": { "type": "Agent::Role", "id": "analyst" }, "attrs": {}, "parents": [] },
+  { "uid": { "type": "Agent::Role", "id": "developer" }, "attrs": {}, "parents": [] },
+  { "uid": { "type": "Agent::User", "id": "alice" }, "attrs": {}, "parents": [{ "type": "Agent::Role", "id": "admin" }] },
+  { "uid": { "type": "Agent::User", "id": "bob" }, "attrs": {}, "parents": [{ "type": "Agent::Role", "id": "analyst" }, { "type": "Agent::Role", "id": "developer" }] },
+  { "uid": { "type": "Agent::McpServer", "id": "default" }, "attrs": {}, "parents": [] }
 ]
 ```
 
@@ -120,9 +121,9 @@ namespace Agent {
 
   entity McpServer;
 
-  entity User = {
-    role: String,
-  };
+  entity Role;
+
+  entity User in [Role];
 
   action "search" appliesTo {
     principal: [User],
@@ -139,6 +140,41 @@ namespace Agent {
 ```
 
 </details>
+
+### Role modeling
+
+Roles are modeled using Cedar's entity hierarchy. The generated policies use `principal in Role::"name"`, which is satisfied by:
+
+- A `User` entity whose parents include the role: `User::"alice"` with parent `Role::"admin"`
+- The role entity itself: `Role::"admin"` (an entity is always `in` itself)
+
+This gives you two options for how you resolve the principal at request time:
+
+**With users** — full audit trail, the principal is the individual user:
+
+```typescript
+const { policies, entities } = new CedarAgentPolicyBuilder(...)
+  .role('admin', ['*'])
+  .role('analyst', ['search'])
+  .user('alice', 'admin')
+  .user('bob', 'analyst')
+  .build()
+
+// principalResolver returns the user identity
+principalResolver: (state) => ({ type: 'Agent::User', id: state.user_id })
+```
+
+**Without users** — simpler, the principal is the role directly:
+
+```typescript
+const { policies, entities } = new CedarAgentPolicyBuilder(...)
+  .role('admin', ['*'])
+  .role('analyst', ['search'])
+  .build()
+
+// principalResolver returns the role
+principalResolver: (state) => ({ type: 'Agent::Role', id: state.role })
+```
 
 ### `tools` — framework-agnostic
 
@@ -186,28 +222,79 @@ constructor { principal } ─────┘                                    
                                                                             at build time
 ```
 
+## Integration with Strands Agents
+
+The [Strands Agents SDK](https://strandsagents.com/docs/user-guide/concepts/agents/interventions/cedar-authorization/) provides `CedarAuthorization` as a vended intervention handler. There are two approaches to modeling role-based access:
+
+### Entity hierarchy (recommended)
+
+Use this package to generate policies and entities, then resolve the principal via `principalResolver`. Roles are expressed structurally through Cedar's entity graph:
+
+```typescript
+import { CedarAgentPolicyBuilder } from 'cedar-agent-policy-builder'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+
+const { policies, entities } = new CedarAgentPolicyBuilder(...)
+  .role('admin', ['*'])
+  .role('analyst', ['search'])
+  .user('alice', 'admin')
+  .user('bob', 'analyst')
+  .build()
+
+const cedar = new CedarAuthorization({
+  policies,
+  entities,
+  principalResolver: (state) => {
+    if (!state.user_id) return undefined
+    return { type: 'Agent::User', id: String(state.user_id) }
+  },
+})
+```
+
+This authorization schema has a few benefits; it allows better static analysis, you can inspect role inheritance, you have a full user audit trail, and no runtime role assertion needed.
+
+### Runtime context (alternative)
+
+Strands also supports passing role via `contextEnricher` into `context.session.role`. In this pattern you write policies manually against `context.session.role`:
+
+```typescript
+const cedar = new CedarAuthorization({
+  policies: `
+    permit(principal, action, resource)
+    when { context.session.role == "admin" };
+  `,
+  principalResolver: (state) => ({ type: 'User', id: String(state.user_id) }),
+  contextEnricher: ({ invocationState }) => ({
+    role: String(invocationState.role ?? 'none'),
+  }),
+})
+```
+
+This is simpler but role is a pure runtime declaration — no entity graph backing, no static analysis of role membership, and role information must be passed on every request.
+
 ## API Reference
 
 ### Constructor (schema configuration)
 
-| Option | Description |
-|--------|-------------|
+| Option      | Description                                                      |
+| ----------- | ---------------------------------------------------------------- |
 | `principal` | Identity resolution. Default: `{ key: 'user_id', type: 'User' }` |
-| `resource` | Custom resource entity. Default: `McpServer::"default"`. |
-| `tools` | MCP tool definitions for schema generation. |
-| `namespace` | Cedar namespace. Default: `"Agent"`. |
+| `resource`  | Custom resource entity. Default: `McpServer::"default"`.         |
+| `tools`     | MCP tool definitions for schema generation.                      |
+| `namespace` | Cedar namespace. Default: `"Agent"`.                             |
 
 ### Policy methods
 
-| Method | Description |
-|--------|-------------|
-| `.role(name, tools)` | Grant a role access to tools. `['*']` = all tools. |
-| `.restrict(tool, { allowedValues })` | Restrict tool arguments to specific values. Empty `{}` = deny tool entirely. |
-| `.rateLimit(tool, max)` | Max calls per session. `0` = always denied. |
-| `.timeWindow({ hourStart, hourEnd })` | Allow tools only during UTC hours. `start == end` = deny all. |
-| `.denyToolsInEnv(env, tools?)` | Deny tools in an environment. No `tools` arg = deny all tools. |
-| `.consent(tools, forRole?)` | Require human consent. No `forRole` = all roles need consent. |
-| `.build()` | Generate `{ policies, entities, schema? }`. |
+| Method                                | Description                                                                       |
+| ------------------------------------- | --------------------------------------------------------------------------------- |
+| `.role(name, tools)`                  | Grant a role access to tools. `['*']` = all tools.                                |
+| `.user(id, ...roles)`                 | Declare a user with one or more roles. Generates a User entity with Role parents. |
+| `.restrict(tool, { allowedValues })`  | Restrict tool arguments to specific values. Empty `{}` = deny tool entirely.      |
+| `.rateLimit(tool, max)`               | Max calls per session. `0` = always denied.                                       |
+| `.timeWindow({ hourStart, hourEnd })` | Allow tools only during UTC hours. `start == end` = deny all.                     |
+| `.denyToolsInEnv(env, tools?)`        | Deny tools in an environment. No `tools` arg = deny all tools.                    |
+| `.consent(tools, forRole?)`           | Require human consent. No `forRole` = all roles need consent.                     |
+| `.build()`                            | Generate `{ policies, entities, schema? }`.                                       |
 
 ### `fromConfig(config)`
 
@@ -219,6 +306,7 @@ import { fromConfig } from 'cedar-agent-policy-builder'
 const { policies, entities } = fromConfig({
   principal: { key: 'user_id', type: 'User' },
   roles: { admin: ['*'], analyst: ['search', 'query_database'] },
+  users: { alice: ['admin'], bob: ['analyst'] },
   restrictions: { query_database: { allowedValues: { database: ['analytics', 'reporting'] } } },
   rateLimits: { send_email: 3 },
   timeWindow: { hourStart: 9, hourEnd: 17 },
@@ -235,7 +323,8 @@ The builder generates Cedar policies following the [cedar-for-agents](https://gi
 
 - **Actions** are named directly after tools (e.g. `Agent::Action::"search"`)
 - **Context** is nested: `context.input.*` for tool arguments, `context.session.*` for runtime state
-- **Principals** are entity types with a `role` attribute
+- **Roles** are Cedar entities; principals are granted access via `principal in Role::"name"`
+- **Users** are entities with Role parents in the entity hierarchy
 - **Resource** defaults to `McpServer::"default"`
 - **Default-deny** — no permit = denied
 

--- a/js/cedar-agent-policy-builder/README.md
+++ b/js/cedar-agent-policy-builder/README.md
@@ -108,31 +108,32 @@ permit(
 **`schema`** — Cedar schema (generated from `.tools()` via the MCP schema generator):
 
 ```cedarschema
-namespace Agent {
-  type searchInput = {
-    query: String
-  };
+type searchInput = {
+  query: String
+};
 
-  type query_databaseInput = {
-    database: String,
-    query: String
-  };
+type query_databaseInput = {
+  database: String,
+  query: String
+};
 
-  entity McpServer;
-  entity User;
+entity McpServer;
 
-  action "search" appliesTo {
-    principal: [User],
-    resource: [McpServer],
-    context: { input: searchInput }
-  };
+entity User = {
+  role: String,
+};
 
-  action "query_database" appliesTo {
-    principal: [User],
-    resource: [McpServer],
-    context: { input: query_databaseInput }
-  };
-}
+action "search" appliesTo {
+  principal: [User],
+  resource: [McpServer],
+  context: { input: searchInput }
+};
+
+action "query_database" appliesTo {
+  principal: [User],
+  resource: [McpServer],
+  context: { input: query_databaseInput }
+};
 ```
 
 </details>
@@ -220,7 +221,7 @@ const { policies, entities } = fromConfig({
   rateLimits: { send_email: 3 },
   timeWindow: { hourStart: 9, hourEnd: 17 },
   denyInEnv: { production: ['delete_record'] },
-  consent: { send_email: ['*'], delete_file: ['*'] },
+  consent: { send_email: true, delete_file: true },
 })
 ```
 

--- a/js/cedar-agent-policy-builder/README.md
+++ b/js/cedar-agent-policy-builder/README.md
@@ -1,0 +1,244 @@
+# cedar-agent-policy-builder
+
+AI agents invoke tools on behalf of users, but today there is no standard way to control *which* user can invoke *which* tool. Developers either hard-code permission checks inside each tool or skip per-tool auth entirely — authorization logic ends up scattered, hard to audit, and impossible to analyze statically.
+
+This package generates [Cedar](https://github.com/cedar-policy/cedar) policies from declarative configuration — roles, argument restrictions, rate limits, time windows, environment rules, and consent gates — so you can express authorization as a standalone artifact without writing Cedar syntax by hand.
+
+Integrates with [`@cedar-policy/mcp-schema-generator-wasm`](https://www.npmjs.com/package/@cedar-policy/mcp-schema-generator-wasm) for schema generation and [`@cedar-policy/cedar-wasm`](https://www.npmjs.com/package/@cedar-policy/cedar-wasm) for policy evaluation.
+
+## Usage
+
+### Builder API
+
+```typescript
+import { CedarAgentPolicyBuilder } from 'cedar-agent-policy-builder'
+import { allTools } from './tools' // your tool definitions
+
+const { policies, entities, schema } = new CedarAgentPolicyBuilder()
+  // Identity: resolve principal from invocationState.user_id as type "User"
+  .principal({ key: 'user_id', type: 'User' })
+  // Roles: admins can use all tools, analysts can only use search and query_database
+  .role('admin', ['*'])
+  .role('analyst', ['search', 'query_database'])
+  // Restriction: analysts can only query the analytics or reporting databases
+  .restrict('query_database', { allowedValues: { database: ['analytics', 'reporting'] } })
+  // Rate limit: max 3 send_email calls per session
+  .rateLimit('send_email', 3)
+  // Time window: tools only allowed between 9am-5pm UTC
+  .timeWindow({ hourStart: 9, hourEnd: 17 })
+  // Environment denial: deny delete_record in production
+  .denyToolsInEnv('production', ['delete_record'])
+  // Consent: send_email and delete_file require human approval before executing
+  .consent(['send_email', 'delete_file'])
+  // Tools: pass tool specs for Cedar schema generation (enables build-time validation)
+  .tools(allTools.map(t => t.spec))
+  .build()
+```
+
+<details>
+<summary><strong>Generated output</strong></summary>
+
+The above produces:
+
+**`policies`** — Cedar permit/forbid rules:
+
+```cedar
+permit(
+  principal is User,
+  action,
+  resource
+) when { principal.role == "admin" };
+
+permit(
+  principal is User,
+  action == Action::"search",
+  resource
+) when { principal.role == "analyst" };
+
+permit(
+  principal is User,
+  action == Action::"query_database",
+  resource
+) when { principal.role == "analyst" };
+
+forbid(
+  principal,
+  action == Action::"query_database",
+  resource
+) when {
+  !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))
+};
+
+forbid(
+  principal,
+  action == Action::"send_email",
+  resource
+) when { context.session has "call_count" && context.session.call_count >= 3 };
+
+forbid(
+  principal,
+  action,
+  resource
+) when { context.session has "hour_utc" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };
+
+forbid(
+  principal,
+  action == Action::"delete_record",
+  resource
+) when { context.session has "environment" && context.session.environment == "production" };
+
+permit(
+  principal is User,
+  action == Action::"send_email",
+  resource
+) when { context.session has "user_consent" && context.session.user_consent == true };
+
+permit(
+  principal is User,
+  action == Action::"delete_file",
+  resource
+) when { context.session has "user_consent" && context.session.user_consent == true };
+```
+
+**`entities`** — Cedar entity data:
+
+```json
+[
+  { "uid": { "type": "Role", "id": "admin" }, "attrs": {}, "parents": [] },
+  { "uid": { "type": "Role", "id": "analyst" }, "attrs": {}, "parents": [] },
+  { "uid": { "type": "McpServer", "id": "default" }, "attrs": {}, "parents": [] }
+]
+```
+
+**`schema`** — Cedar schema (generated from `.tools()` via the MCP schema generator):
+
+```cedarschema
+namespace Agent {
+  type searchInput = {
+    query: String
+  };
+
+  type query_databaseInput = {
+    database: String,
+    query: String
+  };
+
+  entity McpServer;
+  entity User;
+
+  action "search" appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: { input: searchInput }
+  };
+
+  action "query_database" appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: { input: query_databaseInput }
+  };
+}
+```
+
+</details>
+
+### `.tools()` — framework-agnostic
+
+The `.tools()` method accepts any array of `{ name, inputSchema }` objects — the standard MCP tool definition format:
+
+```typescript
+// From Strands tool specs (shown above):
+.tools(allTools.map(t => t.spec))
+
+// From any MCP server's list_tools response:
+.tools(mcpServer.listTools().tools)
+
+// From OpenAI Agents:
+.tools(myTools.map(t => ({ name: t.name, inputSchema: t.parameters })))
+
+// Or defined manually:
+.tools([
+  { name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
+])
+```
+
+### Schema generation and validation
+
+When `.tools()` is provided, `build()` generates a Cedar schema from the tool input schemas via `@cedar-policy/mcp-schema-generator-wasm`. This schema can be used to validate policies at build time:
+
+```typescript
+import { CedarAgentPolicyBuilder } from 'cedar-agent-policy-builder'
+import { validate } from '@cedar-policy/cedar-wasm'
+
+const { policies, schema } = new CedarAgentPolicyBuilder()
+  .role('analyst', ['search'])
+  .tools([{ name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } }])
+  .build()
+
+const result = validate(policies, schema)
+// Catches typos in action names, wrong context field references, etc.
+```
+
+```
+.tools() definitions ──────────┐
+                               ├──► @cedar-policy/mcp-schema-generator-wasm ──► Cedar schema
+.principal()/.resource() ──────┘                                                     │
+                                                                                     ▼
+.role()/.restrict()/.consent() ──► Policy generator ──► Cedar policies ──► validate(policies, schema)
+                                                                            catches typos/type errors
+                                                                            at build time
+```
+
+## API Reference
+
+### Builder methods
+
+| Method | Description |
+|--------|-------------|
+| `.principal({ key, type? })` | Set identity resolution. Default: `{ key: 'user_id', type: 'User' }` |
+| `.role(name, tools)` | Grant a role access to tools. `['*']` = all tools. |
+| `.restrict(tool, { allowedValues })` | Restrict tool arguments to specific values. Empty `{}` = deny tool entirely. |
+| `.rateLimit(tool, max)` | Max calls per session. `0` = always denied. |
+| `.timeWindow({ hourStart, hourEnd })` | Allow tools only during UTC hours. `start == end` = deny all. |
+| `.denyToolsInEnv(env, tools?)` | Deny tools in an environment. No `tools` arg = deny all tools. |
+| `.consent(tools, forRole?)` | Require human consent. No `forRole` = all roles need consent. |
+| `.resource({ type, id })` | Custom resource entity. Default: `McpServer::"default"`. |
+| `.tools(definitions)` | MCP tool definitions for schema generation. |
+| `.namespace(ns)` | Cedar namespace. Default: `"Agent"`. |
+| `.build()` | Generate `{ policies, entities, schema? }`. |
+
+### `fromConfig(config)`
+
+Same as the builder but from a plain object. Useful for loading authorization config from a JSON file or environment-specific config:
+
+```typescript
+import { fromConfig } from 'cedar-agent-policy-builder'
+
+const { policies, entities } = fromConfig({
+  principal: { key: 'user_id', type: 'User' },
+  roles: { admin: ['*'], analyst: ['search', 'query_database'] },
+  restrictions: { query_database: { allowedValues: { database: ['analytics', 'reporting'] } } },
+  rateLimits: { send_email: 3 },
+  timeWindow: { hourStart: 9, hourEnd: 17 },
+  denyInEnv: { production: ['delete_record'] },
+  consent: { send_email: ['*'], delete_file: ['*'] },
+})
+```
+
+See `CedarAgentConfig` type for the full shape.
+
+## How it works
+
+The builder generates Cedar policies following the [cedar-for-agents](https://github.com/cedar-policy/cedar-for-agents) MCP schema generator conventions:
+
+- **Actions** are named directly after tools (e.g. `Action::"search"`)
+- **Context** is nested: `context.input.*` for tool arguments, `context.session.*` for runtime state
+- **Principals** are entity types with a `role` attribute
+- **Resource** defaults to `McpServer::"default"`
+- **Default-deny** — no permit = denied
+
+All `context.session.*` field accesses include `has` guards for safety (Cedar errors on missing fields rather than returning false).
+
+## License
+
+Apache-2.0

--- a/js/cedar-agent-policy-builder/README.md
+++ b/js/cedar-agent-policy-builder/README.md
@@ -39,26 +39,26 @@ The above produces:
 
 ```cedar
 permit(
-  principal is User,
+  principal is Agent::User,
   action,
   resource
 ) when { principal.role == "admin" };
 
 permit(
-  principal is User,
-  action == Action::"search",
+  principal is Agent::User,
+  action == Agent::Action::"search",
   resource
 ) when { principal.role == "analyst" };
 
 permit(
-  principal is User,
-  action == Action::"query_database",
+  principal is Agent::User,
+  action == Agent::Action::"query_database",
   resource
 ) when { principal.role == "analyst" };
 
 forbid(
   principal,
-  action == Action::"query_database",
+  action == Agent::Action::"query_database",
   resource
 ) when {
   !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))
@@ -66,7 +66,7 @@ forbid(
 
 forbid(
   principal,
-  action == Action::"send_email",
+  action == Agent::Action::"send_email",
   resource
 ) when { context.session has "call_count" && context.session.call_count >= 3 };
 
@@ -78,19 +78,19 @@ forbid(
 
 forbid(
   principal,
-  action == Action::"delete_record",
+  action == Agent::Action::"delete_record",
   resource
 ) when { context.session has "environment" && context.session.environment == "production" };
 
 permit(
-  principal is User,
-  action == Action::"send_email",
+  principal is Agent::User,
+  action == Agent::Action::"send_email",
   resource
 ) when { context.session has "user_consent" && context.session.user_consent == true };
 
 permit(
-  principal is User,
-  action == Action::"delete_file",
+  principal is Agent::User,
+  action == Agent::Action::"delete_file",
   resource
 ) when { context.session has "user_consent" && context.session.user_consent == true };
 ```
@@ -108,32 +108,34 @@ permit(
 **`schema`** — Cedar schema (generated from `.tools()` via the MCP schema generator):
 
 ```cedarschema
-type searchInput = {
-  query: String
-};
+namespace Agent {
+  type searchInput = {
+    query: String
+  };
 
-type query_databaseInput = {
-  database: String,
-  query: String
-};
+  type query_databaseInput = {
+    database: String,
+    query: String
+  };
 
-entity McpServer;
+  entity McpServer;
 
-entity User = {
-  role: String,
-};
+  entity User = {
+    role: String,
+  };
 
-action "search" appliesTo {
-  principal: [User],
-  resource: [McpServer],
-  context: { input: searchInput }
-};
+  action "search" appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: { input: searchInput }
+  };
 
-action "query_database" appliesTo {
-  principal: [User],
-  resource: [McpServer],
-  context: { input: query_databaseInput }
-};
+  action "query_database" appliesTo {
+    principal: [User],
+    resource: [McpServer],
+    context: { input: query_databaseInput }
+  };
+}
 ```
 
 </details>
@@ -231,7 +233,7 @@ See `CedarAgentConfig` type for the full shape.
 
 The builder generates Cedar policies following the [cedar-for-agents](https://github.com/cedar-policy/cedar-for-agents) MCP schema generator conventions:
 
-- **Actions** are named directly after tools (e.g. `Action::"search"`)
+- **Actions** are named directly after tools (e.g. `Agent::Action::"search"`)
 - **Context** is nested: `context.input.*` for tool arguments, `context.session.*` for runtime state
 - **Principals** are entity types with a `role` attribute
 - **Resource** defaults to `McpServer::"default"`

--- a/js/cedar-agent-policy-builder/README.md
+++ b/js/cedar-agent-policy-builder/README.md
@@ -102,7 +102,7 @@ permit(
   { "uid": { "type": "Agent::Role", "id": "developer" }, "attrs": {}, "parents": [] },
   { "uid": { "type": "Agent::User", "id": "alice" }, "attrs": {}, "parents": [{ "type": "Agent::Role", "id": "admin" }] },
   { "uid": { "type": "Agent::User", "id": "bob" }, "attrs": {}, "parents": [{ "type": "Agent::Role", "id": "analyst" }, { "type": "Agent::Role", "id": "developer" }] },
-  { "uid": { "type": "Agent::McpServer", "id": "default" }, "attrs": {}, "parents": [] }
+  { "uid": { "type": "Agent::Resource", "id": "default" }, "attrs": {}, "parents": [] }
 ]
 ```
 
@@ -119,7 +119,7 @@ namespace Agent {
     query: String
   };
 
-  entity McpServer;
+  entity Resource;
 
   entity Role;
 
@@ -127,13 +127,13 @@ namespace Agent {
 
   action "search" appliesTo {
     principal: [User],
-    resource: [McpServer],
+    resource: [Resource],
     context: { input: searchInput }
   };
 
   action "query_database" appliesTo {
     principal: [User],
-    resource: [McpServer],
+    resource: [Resource],
     context: { input: query_databaseInput }
   };
 }
@@ -279,7 +279,7 @@ This is simpler but role is a pure runtime declaration — no entity graph backi
 | Option      | Description                                                      |
 | ----------- | ---------------------------------------------------------------- |
 | `principal` | Identity resolution. Default: `{ key: 'user_id', type: 'User' }` |
-| `resource`  | Custom resource entity. Default: `McpServer::"default"`.         |
+| `resource`  | Custom resource entity. Default: `Resource::"default"`.         |
 | `tools`     | MCP tool definitions for schema generation.                      |
 | `namespace` | Cedar namespace. Default: `"Agent"`.                             |
 
@@ -325,7 +325,7 @@ The builder generates Cedar policies following the [cedar-for-agents](https://gi
 - **Context** is nested: `context.input.*` for tool arguments, `context.session.*` for runtime state
 - **Roles** are Cedar entities; principals are granted access via `principal in Role::"name"`
 - **Users** are entities with Role parents in the entity hierarchy
-- **Resource** defaults to `McpServer::"default"`
+- **Resource** defaults to `Resource::"default"`
 - **Default-deny** — no permit = denied
 
 All `context.session.*` field accesses include `has` guards for safety (Cedar errors on missing fields rather than returning false).

--- a/js/cedar-agent-policy-builder/README.md
+++ b/js/cedar-agent-policy-builder/README.md
@@ -14,24 +14,19 @@ Integrates with [`@cedar-policy/mcp-schema-generator-wasm`](https://www.npmjs.co
 import { CedarAgentPolicyBuilder } from 'cedar-agent-policy-builder'
 import { allTools } from './tools' // your tool definitions
 
-const { policies, entities, schema } = new CedarAgentPolicyBuilder()
-  // Identity: resolve principal from invocationState.user_id as type "User"
-  .principal({ key: 'user_id', type: 'User' })
-  // Roles: admins can use all tools, analysts can only use search and query_database
+const { policies, entities, schema } = new CedarAgentPolicyBuilder({
+  // Schema configuration — defines types and structure
+  principal: { key: 'user_id', type: 'User' },
+  tools: allTools.map(t => t.spec), // MCP tool definitions for schema generation
+})
+  // Policy configuration — defines who can do what
   .role('admin', ['*'])
   .role('analyst', ['search', 'query_database'])
-  // Restriction: analysts can only query the analytics or reporting databases
   .restrict('query_database', { allowedValues: { database: ['analytics', 'reporting'] } })
-  // Rate limit: max 3 send_email calls per session
   .rateLimit('send_email', 3)
-  // Time window: tools only allowed between 9am-5pm UTC
   .timeWindow({ hourStart: 9, hourEnd: 17 })
-  // Environment denial: deny delete_record in production
   .denyToolsInEnv('production', ['delete_record'])
-  // Consent: send_email and delete_file require human approval before executing
   .consent(['send_email', 'delete_file'])
-  // Tools: pass tool specs for Cedar schema generation (enables build-time validation)
-  .tools(allTools.map(t => t.spec))
   .build()
 ```
 
@@ -142,37 +137,36 @@ namespace Agent {
 
 </details>
 
-### `.tools()` — framework-agnostic
+### `tools` — framework-agnostic
 
-The `.tools()` method accepts any array of `{ name, inputSchema }` objects — the standard MCP tool definition format:
+The `tools` constructor option accepts any array of `{ name, inputSchema }` objects — the standard MCP tool definition format:
 
 ```typescript
-// From Strands tool specs (shown above):
-.tools(allTools.map(t => t.spec))
+// From Strands tool specs:
+new CedarAgentPolicyBuilder({ tools: allTools.map(t => t.spec) })
 
 // From any MCP server's list_tools response:
-.tools(mcpServer.listTools().tools)
+new CedarAgentPolicyBuilder({ tools: mcpServer.listTools().tools })
 
 // From OpenAI Agents:
-.tools(myTools.map(t => ({ name: t.name, inputSchema: t.parameters })))
+new CedarAgentPolicyBuilder({ tools: myTools.map(t => ({ name: t.name, inputSchema: t.parameters })) })
 
 // Or defined manually:
-.tools([
-  { name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
-])
+new CedarAgentPolicyBuilder({ tools: [{ name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } }] })
 ```
 
 ### Schema generation and validation
 
-When `.tools()` is provided, `build()` generates a Cedar schema from the tool input schemas via `@cedar-policy/mcp-schema-generator-wasm`. This schema can be used to validate policies at build time:
+When `tools` is provided, `build()` generates a Cedar schema from the tool input schemas via `@cedar-policy/mcp-schema-generator-wasm`. This schema can be used to validate policies at build time:
 
 ```typescript
 import { CedarAgentPolicyBuilder } from 'cedar-agent-policy-builder'
 import { validate } from '@cedar-policy/cedar-wasm'
 
-const { policies, schema } = new CedarAgentPolicyBuilder()
+const { policies, schema } = new CedarAgentPolicyBuilder({
+  tools: [{ name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } }],
+})
   .role('analyst', ['search'])
-  .tools([{ name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } }])
   .build()
 
 const result = validate(policies, schema)
@@ -180,9 +174,9 @@ const result = validate(policies, schema)
 ```
 
 ```
-.tools() definitions ──────────┐
+constructor { tools } ─────────┐
                                ├──► @cedar-policy/mcp-schema-generator-wasm ──► Cedar schema
-.principal()/.resource() ──────┘                                                     │
+constructor { principal } ─────┘                                                     │
                                                                                      ▼
 .role()/.restrict()/.consent() ──► Policy generator ──► Cedar policies ──► validate(policies, schema)
                                                                             catches typos/type errors
@@ -191,20 +185,25 @@ const result = validate(policies, schema)
 
 ## API Reference
 
-### Builder methods
+### Constructor (schema configuration)
+
+| Option | Description |
+|--------|-------------|
+| `principal` | Identity resolution. Default: `{ key: 'user_id', type: 'User' }` |
+| `resource` | Custom resource entity. Default: `McpServer::"default"`. |
+| `tools` | MCP tool definitions for schema generation. |
+| `namespace` | Cedar namespace. Default: `"Agent"`. |
+
+### Policy methods
 
 | Method | Description |
 |--------|-------------|
-| `.principal({ key, type? })` | Set identity resolution. Default: `{ key: 'user_id', type: 'User' }` |
 | `.role(name, tools)` | Grant a role access to tools. `['*']` = all tools. |
 | `.restrict(tool, { allowedValues })` | Restrict tool arguments to specific values. Empty `{}` = deny tool entirely. |
 | `.rateLimit(tool, max)` | Max calls per session. `0` = always denied. |
 | `.timeWindow({ hourStart, hourEnd })` | Allow tools only during UTC hours. `start == end` = deny all. |
 | `.denyToolsInEnv(env, tools?)` | Deny tools in an environment. No `tools` arg = deny all tools. |
 | `.consent(tools, forRole?)` | Require human consent. No `forRole` = all roles need consent. |
-| `.resource({ type, id })` | Custom resource entity. Default: `McpServer::"default"`. |
-| `.tools(definitions)` | MCP tool definitions for schema generation. |
-| `.namespace(ns)` | Cedar namespace. Default: `"Agent"`. |
 | `.build()` | Generate `{ policies, entities, schema? }`. |
 
 ### `fromConfig(config)`

--- a/js/cedar-agent-policy-builder/package-lock.json
+++ b/js/cedar-agent-policy-builder/package-lock.json
@@ -1,0 +1,1659 @@
+{
+  "name": "cedar-agent-policy-builder",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cedar-agent-policy-builder",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cedar-policy/cedar-wasm": "^4.11.0",
+        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cedar-policy/cedar-wasm": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@cedar-policy/cedar-wasm/-/cedar-wasm-4.11.0.tgz",
+      "integrity": "sha512-jIpMGPXKu6spe9PMXdSUqFMK5nJmAyTxRKRA2eegxQhGRRjDrbPuQB2C0+ARGs2OjqhoexgGODf8Y/rPACQI7A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cedar-policy/mcp-schema-generator-wasm": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@cedar-policy/mcp-schema-generator-wasm/-/mcp-schema-generator-wasm-0.6.0.tgz",
+      "integrity": "sha512-X52DtpYwoYqm6e1ddUE2jNuLt98rIM7cfJpOuKfJn3RGtbzxjk2oSg5g3v4oNoXX/GKWmXCo7i/akrJA9AtGVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
+      "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
+      "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
+      "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
+      "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
+      "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
+      "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
+      "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
+      "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
+      "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
+      "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
+      "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
+      "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
+      "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
+      "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
+      "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
+      "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
+      "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
+      "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
+      "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
+      "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
+      "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
+      "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
+      "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.0",
+        "@rollup/rollup-android-arm64": "4.61.0",
+        "@rollup/rollup-darwin-arm64": "4.61.0",
+        "@rollup/rollup-darwin-x64": "4.61.0",
+        "@rollup/rollup-freebsd-arm64": "4.61.0",
+        "@rollup/rollup-freebsd-x64": "4.61.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
+        "@rollup/rollup-linux-arm64-musl": "4.61.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
+        "@rollup/rollup-linux-loong64-musl": "4.61.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-musl": "4.61.0",
+        "@rollup/rollup-openbsd-x64": "4.61.0",
+        "@rollup/rollup-openharmony-arm64": "4.61.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
+        "@rollup/rollup-win32-x64-gnu": "4.61.0",
+        "@rollup/rollup-win32-x64-msvc": "4.61.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/js/cedar-agent-policy-builder/package-lock.json
+++ b/js/cedar-agent-policy-builder/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cedar-policy/cedar-wasm": "^4.11.0",
-        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0"
+        "@cedar-policy/cedar-wasm": "4.11.0",
+        "@cedar-policy/mcp-schema-generator-wasm": "0.6.0"
       },
       "devDependencies": {
         "typescript": "^5.5.0",
@@ -573,9 +573,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -590,9 +587,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -607,9 +601,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -624,9 +615,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -641,9 +629,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -658,9 +643,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -675,9 +657,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -692,9 +671,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,9 +685,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -726,9 +699,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,9 +713,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +727,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -777,9 +741,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/js/cedar-agent-policy-builder/package.json
+++ b/js/cedar-agent-policy-builder/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "cedar-agent-policy-builder",
+  "version": "0.1.0",
+  "description": "Generate Cedar policies and entities for agent authorization from declarative configuration",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepare": "npm run build"
+  },
+  "dependencies": {
+    "@cedar-policy/cedar-wasm": "4.11.0",
+    "@cedar-policy/mcp-schema-generator-wasm": "0.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "Apache-2.0"
+}

--- a/js/cedar-agent-policy-builder/src/builder.ts
+++ b/js/cedar-agent-policy-builder/src/builder.ts
@@ -60,6 +60,12 @@ export class CedarAgentPolicyBuilder {
     return this
   }
 
+  user(id: string, ...roles: string[]): this {
+    this._config.users ??= {}
+    this._config.users[id] = roles
+    return this
+  }
+
   restrict(tool: string, config: { allowedValues: Record<string, unknown[]> }): this {
     this._config.restrictions ??= {}
     this._config.restrictions[tool] = config

--- a/js/cedar-agent-policy-builder/src/builder.ts
+++ b/js/cedar-agent-policy-builder/src/builder.ts
@@ -1,17 +1,45 @@
-import type { BuildResult, CedarAgentConfig, SchemaConfig } from './types.js'
+import type { ValidationAnswer } from '@cedar-policy/cedar-wasm'
+import type { BuildResult, CedarAgentConfig, SchemaConfig, ValidationResult } from './types.js'
 import { generatePolicies } from './policy-generators.js'
 import { generateEntities } from './entities.js'
 import { generateSchema } from './schema.js'
+import { validate as cedarValidate } from '@cedar-policy/cedar-wasm/nodejs'
 
 export function fromConfig(config: CedarAgentConfig): BuildResult {
-  const result: BuildResult = {
-    policies: generatePolicies(config),
-    entities: generateEntities(config),
+  const policies = generatePolicies(config)
+  const entities = generateEntities(config)
+  const schema = config.tools ? generateSchema(config) : undefined
+
+  return {
+    policies,
+    entities,
+    schema,
+    validate(): ValidationResult {
+      if (!schema) {
+        return { valid: true, errors: [], warnings: [] }
+      }
+      const result: ValidationAnswer = cedarValidate({
+        policies: { staticPolicies: policies, templates: {} },
+        schema,
+        validationSettings: { mode: 'strict' },
+      })
+      if (result.type !== 'success') {
+        const messages = result.errors.map((e) => e.message).join('; ')
+        return { valid: false, errors: [{ policyId: '', message: messages || 'validation failed' }], warnings: [] }
+      }
+      const errors = result.validationErrors.map((e) => ({
+        policyId: e.policyId,
+        message: e.error.message,
+        help: e.error.help ?? undefined,
+      }))
+      const warnings = result.validationWarnings.map((e) => ({
+        policyId: e.policyId,
+        message: e.error.message,
+        help: e.error.help ?? undefined,
+      }))
+      return { valid: errors.length === 0, errors, warnings }
+    },
   }
-  if (config.tools) {
-    result.schema = generateSchema(config)
-  }
-  return result
 }
 
 export class CedarAgentPolicyBuilder {
@@ -80,6 +108,17 @@ export class CedarAgentPolicyBuilder {
   build(): BuildResult {
     this._warnUnknownTools()
     return fromConfig(this._config)
+  }
+
+  /** Build and validate in one step. Throws if policies fail schema validation. */
+  buildAndValidate(): BuildResult {
+    const result = this.build()
+    const validation = result.validate()
+    if (!validation.valid) {
+      const messages = validation.errors.map((e) => e.message).join('; ')
+      throw new Error(`Cedar policy validation failed: ${messages}`)
+    }
+    return result
   }
 
   private _warnUnknownTools(): void {

--- a/js/cedar-agent-policy-builder/src/builder.ts
+++ b/js/cedar-agent-policy-builder/src/builder.ts
@@ -1,4 +1,4 @@
-import type { BuildResult, CedarAgentConfig, McpToolDefinition, PrincipalConfig } from './types.js'
+import type { BuildResult, CedarAgentConfig, McpToolDefinition, PrincipalConfig, SchemaConfig } from './types.js'
 import { generatePolicies } from './policy-generators.js'
 import { generateEntities } from './entities.js'
 import { generateSchema } from './schema.js'
@@ -15,11 +15,15 @@ export function fromConfig(config: CedarAgentConfig): BuildResult {
 }
 
 export class CedarAgentPolicyBuilder {
-  private _config: CedarAgentConfig = { principal: { key: 'user_id' } }
+  private _config: CedarAgentConfig
 
-  principal(config: PrincipalConfig): this {
-    this._config.principal = config
-    return this
+  constructor(schema?: SchemaConfig) {
+    this._config = {
+      principal: schema?.principal ?? { key: 'user_id' },
+      resource: schema?.resource,
+      tools: schema?.tools,
+      namespace: schema?.namespace,
+    }
   }
 
   role(name: string, tools: string[]): this {
@@ -66,21 +70,6 @@ export class CedarAgentPolicyBuilder {
         this._config.consent[tool] = ['*']
       }
     }
-    return this
-  }
-
-  resource(config: { type: string; id: string }): this {
-    this._config.resource = config
-    return this
-  }
-
-  tools(definitions: McpToolDefinition[]): this {
-    this._config.tools = definitions
-    return this
-  }
-
-  namespace(ns: string): this {
-    this._config.namespace = ns
     return this
   }
 

--- a/js/cedar-agent-policy-builder/src/builder.ts
+++ b/js/cedar-agent-policy-builder/src/builder.ts
@@ -1,0 +1,121 @@
+import type { BuildResult, CedarAgentConfig, McpToolDefinition, PrincipalConfig } from './types.js'
+import { generatePolicies } from './policy-generators.js'
+import { generateEntities } from './entities.js'
+import { generateSchema } from './schema.js'
+
+export function fromConfig(config: CedarAgentConfig): BuildResult {
+  const result: BuildResult = {
+    policies: generatePolicies(config),
+    entities: generateEntities(config),
+  }
+  if (config.tools) {
+    result.schema = generateSchema(config)
+  }
+  return result
+}
+
+export class CedarAgentPolicyBuilder {
+  private _config: CedarAgentConfig = { principal: { key: 'user_id' } }
+
+  principal(config: PrincipalConfig): this {
+    this._config.principal = config
+    return this
+  }
+
+  role(name: string, tools: string[]): this {
+    this._config.roles ??= {}
+    this._config.roles[name] = tools
+    return this
+  }
+
+  restrict(tool: string, config: { allowedValues: Record<string, unknown[]> }): this {
+    this._config.restrictions ??= {}
+    this._config.restrictions[tool] = config
+    return this
+  }
+
+  // Note: maxPerSession of 0 means the tool is effectively denied (call_count >= 0 is always true).
+  rateLimit(tool: string, maxPerSession: number): this {
+    this._config.rateLimits ??= {}
+    this._config.rateLimits[tool] = maxPerSession
+    return this
+  }
+
+  // Note: hourStart == hourEnd produces a zero-width window that denies at all hours.
+  timeWindow(config: { hourStart: number; hourEnd: number }): this {
+    this._config.timeWindow = config
+    return this
+  }
+
+  denyToolsInEnv(env: string, tools?: string[]): this {
+    this._config.denyInEnv ??= {}
+    this._config.denyInEnv[env] = tools ?? ['*']
+    return this
+  }
+
+  /** Require human consent before executing these tools.
+   * Without forRole: all roles need consent (overwrites any prior role-specific consent for these tools).
+   * With forRole: only that role needs consent (accumulates with other role-specific calls). */
+  consent(tools: string[], forRole?: string): this {
+    this._config.consent ??= {}
+    for (const tool of tools) {
+      this._config.consent[tool] ??= []
+      if (forRole) {
+        this._config.consent[tool].push(forRole)
+      } else {
+        this._config.consent[tool] = ['*']
+      }
+    }
+    return this
+  }
+
+  resource(config: { type: string; id: string }): this {
+    this._config.resource = config
+    return this
+  }
+
+  tools(definitions: McpToolDefinition[]): this {
+    this._config.tools = definitions
+    return this
+  }
+
+  namespace(ns: string): this {
+    this._config.namespace = ns
+    return this
+  }
+
+  build(): BuildResult {
+    this._warnUnknownTools()
+    return fromConfig(this._config)
+  }
+
+  private _warnUnknownTools(): void {
+    if (!this._config.roles) return
+    const declaredTools = new Set(
+      Object.values(this._config.roles).flat().filter((t) => t !== '*')
+    )
+    if (declaredTools.size === 0) return
+
+    const referenced = new Set<string>()
+    if (this._config.restrictions) {
+      for (const tool of Object.keys(this._config.restrictions)) referenced.add(tool)
+    }
+    if (this._config.rateLimits) {
+      for (const tool of Object.keys(this._config.rateLimits)) referenced.add(tool)
+    }
+    if (this._config.denyInEnv) {
+      for (const tools of Object.values(this._config.denyInEnv)) {
+        for (const tool of tools) if (tool !== '*') referenced.add(tool)
+      }
+    }
+    if (this._config.consent) {
+      for (const tool of Object.keys(this._config.consent)) referenced.add(tool)
+    }
+
+    for (const tool of referenced) {
+      if (!declaredTools.has(tool)) {
+        console.warn(`[cedar-agent-policy-builder] Warning: "${tool}" is referenced in restrict/denyToolsInEnv/consent but not declared in any role`)
+      }
+    }
+  }
+}

--- a/js/cedar-agent-policy-builder/src/builder.ts
+++ b/js/cedar-agent-policy-builder/src/builder.ts
@@ -1,4 +1,4 @@
-import type { BuildResult, CedarAgentConfig, McpToolDefinition, PrincipalConfig, SchemaConfig } from './types.js'
+import type { BuildResult, CedarAgentConfig, SchemaConfig } from './types.js'
 import { generatePolicies } from './policy-generators.js'
 import { generateEntities } from './entities.js'
 import { generateSchema } from './schema.js'
@@ -63,11 +63,15 @@ export class CedarAgentPolicyBuilder {
   consent(tools: string[], forRole?: string): this {
     this._config.consent ??= {}
     for (const tool of tools) {
-      this._config.consent[tool] ??= []
       if (forRole) {
-        this._config.consent[tool].push(forRole)
+        const current = this._config.consent[tool]
+        if (!current || current === true) {
+          this._config.consent[tool] = [forRole]
+        } else {
+          current.push(forRole)
+        }
       } else {
-        this._config.consent[tool] = ['*']
+        this._config.consent[tool] = true
       }
     }
     return this

--- a/js/cedar-agent-policy-builder/src/entities.ts
+++ b/js/cedar-agent-policy-builder/src/entities.ts
@@ -3,15 +3,27 @@ import type { CedarAgentConfig } from './types.js'
 
 export function generateEntities(config: CedarAgentConfig): EntityJson[] {
   const entities: EntityJson[] = []
+  const ns = config.namespace ?? 'Agent'
 
   if (config.roles) {
     for (const roleName of Object.keys(config.roles)) {
-      entities.push({ uid: { type: 'Role', id: roleName }, attrs: {}, parents: [] })
+      entities.push({ uid: { type: `${ns}::Role`, id: roleName }, attrs: {}, parents: [] })
+    }
+  }
+
+  if (config.users) {
+    const principalType = config.principal.type ?? 'User'
+    for (const [userId, roles] of Object.entries(config.users)) {
+      entities.push({
+        uid: { type: `${ns}::${principalType}`, id: userId },
+        attrs: {},
+        parents: roles.map((r) => ({ type: `${ns}::Role`, id: r })),
+      })
     }
   }
 
   const resource = config.resource ?? { type: 'McpServer', id: 'default' }
-  entities.push({ uid: resource, attrs: {}, parents: [] })
+  entities.push({ uid: { type: `${ns}::${resource.type}`, id: resource.id }, attrs: {}, parents: [] })
 
   return entities
 }

--- a/js/cedar-agent-policy-builder/src/entities.ts
+++ b/js/cedar-agent-policy-builder/src/entities.ts
@@ -22,7 +22,7 @@ export function generateEntities(config: CedarAgentConfig): EntityJson[] {
     }
   }
 
-  const resource = config.resource ?? { type: 'McpServer', id: 'default' }
+  const resource = config.resource ?? { type: 'Resource', id: 'default' }
   entities.push({ uid: { type: `${ns}::${resource.type}`, id: resource.id }, attrs: {}, parents: [] })
 
   return entities

--- a/js/cedar-agent-policy-builder/src/entities.ts
+++ b/js/cedar-agent-policy-builder/src/entities.ts
@@ -1,0 +1,17 @@
+import type { EntityJson } from '@cedar-policy/cedar-wasm'
+import type { CedarAgentConfig } from './types.js'
+
+export function generateEntities(config: CedarAgentConfig): EntityJson[] {
+  const entities: EntityJson[] = []
+
+  if (config.roles) {
+    for (const roleName of Object.keys(config.roles)) {
+      entities.push({ uid: { type: 'Role', id: roleName }, attrs: {}, parents: [] })
+    }
+  }
+
+  const resource = config.resource ?? { type: 'McpServer', id: 'default' }
+  entities.push({ uid: resource, attrs: {}, parents: [] })
+
+  return entities
+}

--- a/js/cedar-agent-policy-builder/src/index.ts
+++ b/js/cedar-agent-policy-builder/src/index.ts
@@ -1,0 +1,2 @@
+export type { PrincipalConfig, CedarAgentConfig, McpToolDefinition, BuildResult } from './types.js'
+export { CedarAgentPolicyBuilder, fromConfig } from './builder.js'

--- a/js/cedar-agent-policy-builder/src/index.ts
+++ b/js/cedar-agent-policy-builder/src/index.ts
@@ -1,2 +1,2 @@
-export type { PrincipalConfig, SchemaConfig, CedarAgentConfig, McpToolDefinition, BuildResult } from './types.js'
+export type { PrincipalConfig, SchemaConfig, CedarAgentConfig, McpToolDefinition, BuildResult, ValidationResult, ValidationError } from './types.js'
 export { CedarAgentPolicyBuilder, fromConfig } from './builder.js'

--- a/js/cedar-agent-policy-builder/src/index.ts
+++ b/js/cedar-agent-policy-builder/src/index.ts
@@ -1,2 +1,2 @@
-export type { PrincipalConfig, CedarAgentConfig, McpToolDefinition, BuildResult } from './types.js'
+export type { PrincipalConfig, SchemaConfig, CedarAgentConfig, McpToolDefinition, BuildResult } from './types.js'
 export { CedarAgentPolicyBuilder, fromConfig } from './builder.js'

--- a/js/cedar-agent-policy-builder/src/policy-generators.ts
+++ b/js/cedar-agent-policy-builder/src/policy-generators.ts
@@ -23,6 +23,7 @@ function getConsentToolsForRole(config: CedarAgentConfig, roleName: string): Set
 
 function generateRolePolicies(config: CedarAgentConfig): string[] {
   if (!config.roles) return []
+  const ns = config.namespace ?? 'Agent'
   const principalType = config.principal.type ?? 'User'
   const policies: string[] = []
 
@@ -33,14 +34,14 @@ function generateRolePolicies(config: CedarAgentConfig): string[] {
       if (consentToolsForRole.size > 0) {
         // Wildcard with consent exclusions: permit all actions EXCEPT consent-gated tools for this role
         const exclusions = [...consentToolsForRole]
-          .map((t) => `action == Action::"${escapeCedarString(t)}"`)
+          .map((t) => `action == ${ns}::Action::"${escapeCedarString(t)}"`)
           .join(' || ')
         policies.push(
-          `permit(\n  principal is ${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" && !(${exclusions}) };`
+          `permit(\n  principal is ${ns}::${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" && !(${exclusions}) };`
         )
       } else {
         policies.push(
-          `permit(\n  principal is ${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
+          `permit(\n  principal is ${ns}::${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
         )
       }
     } else {
@@ -48,7 +49,7 @@ function generateRolePolicies(config: CedarAgentConfig): string[] {
       const filteredTools = tools.filter((t) => !consentToolsForRole.has(t))
       for (const tool of filteredTools) {
         policies.push(
-          `permit(\n  principal is ${principalType},\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
+          `permit(\n  principal is ${ns}::${principalType},\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
         )
       }
     }
@@ -59,6 +60,7 @@ function generateRolePolicies(config: CedarAgentConfig): string[] {
 
 function generateRestrictionPolicies(config: CedarAgentConfig): string[] {
   if (!config.restrictions) return []
+  const ns = config.namespace ?? 'Agent'
   const policies: string[] = []
 
   for (const [tool, restriction] of Object.entries(config.restrictions)) {
@@ -66,7 +68,7 @@ function generateRestrictionPolicies(config: CedarAgentConfig): string[] {
     if (fields.length === 0) {
       // Empty allowedValues = no values are allowed, deny the tool entirely
       policies.push(
-        `forbid(\n  principal,\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n);`
+        `forbid(\n  principal,\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n);`
       )
       continue
     }
@@ -75,7 +77,7 @@ function generateRestrictionPolicies(config: CedarAgentConfig): string[] {
         .map((v) => `context.input.${field} == ${JSON.stringify(v)}`)
         .join(' || ')
       policies.push(
-        `forbid(\n  principal,\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when {\n  !(context.input has "${escapeCedarString(field)}" && (${valueChecks}))\n};`
+        `forbid(\n  principal,\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when {\n  !(context.input has "${escapeCedarString(field)}" && (${valueChecks}))\n};`
       )
     }
   }
@@ -85,11 +87,12 @@ function generateRestrictionPolicies(config: CedarAgentConfig): string[] {
 
 function generateRateLimitPolicies(config: CedarAgentConfig): string[] {
   if (!config.rateLimits) return []
+  const ns = config.namespace ?? 'Agent'
   const policies: string[] = []
 
   for (const [tool, max] of Object.entries(config.rateLimits)) {
     policies.push(
-      `forbid(\n  principal,\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= ${max} };`
+      `forbid(\n  principal,\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= ${max} };`
     )
   }
 
@@ -106,6 +109,7 @@ function generateTimeWindowPolicy(config: CedarAgentConfig): string[] {
 
 function generateEnvDenialPolicies(config: CedarAgentConfig): string[] {
   if (!config.denyInEnv) return []
+  const ns = config.namespace ?? 'Agent'
   const policies: string[] = []
 
   for (const [env, tools] of Object.entries(config.denyInEnv)) {
@@ -117,7 +121,7 @@ function generateEnvDenialPolicies(config: CedarAgentConfig): string[] {
     } else {
       for (const tool of tools) {
         policies.push(
-          `forbid(\n  principal,\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "environment" && context.session.environment == "${escapeCedarString(env)}" };`
+          `forbid(\n  principal,\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "environment" && context.session.environment == "${escapeCedarString(env)}" };`
         )
       }
     }
@@ -128,6 +132,7 @@ function generateEnvDenialPolicies(config: CedarAgentConfig): string[] {
 
 function generateConsentPolicies(config: CedarAgentConfig): string[] {
   if (!config.consent) return []
+  const ns = config.namespace ?? 'Agent'
   const principalType = config.principal.type ?? 'User'
   const policies: string[] = []
 
@@ -136,12 +141,12 @@ function generateConsentPolicies(config: CedarAgentConfig): string[] {
     if (roles.includes('*')) {
       // All roles need consent — no role check in the policy
       policies.push(
-        `permit(\n  principal is ${principalType},\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "user_consent" && context.session.user_consent == true };`
+        `permit(\n  principal is ${ns}::${principalType},\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "user_consent" && context.session.user_consent == true };`
       )
     } else {
       for (const role of roles) {
         policies.push(
-          `permit(\n  principal is ${principalType},\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(role)}" && context.session has "user_consent" && context.session.user_consent == true };`
+          `permit(\n  principal is ${ns}::${principalType},\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(role)}" && context.session has "user_consent" && context.session.user_consent == true };`
         )
       }
     }

--- a/js/cedar-agent-policy-builder/src/policy-generators.ts
+++ b/js/cedar-agent-policy-builder/src/policy-generators.ts
@@ -1,0 +1,131 @@
+import type { CedarAgentConfig } from './types.js'
+
+export function escapeCedarString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+function generateRolePolicies(config: CedarAgentConfig): string[] {
+  if (!config.roles) return []
+  const principalType = config.principal.type ?? 'User'
+  const policies: string[] = []
+
+  for (const [roleName, tools] of Object.entries(config.roles)) {
+    if (tools.includes('*')) {
+      policies.push(
+        `permit(\n  principal is ${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
+      )
+    } else {
+      for (const tool of tools) {
+        policies.push(
+          `permit(\n  principal is ${principalType},\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
+        )
+      }
+    }
+  }
+
+  return policies
+}
+
+function generateRestrictionPolicies(config: CedarAgentConfig): string[] {
+  if (!config.restrictions) return []
+  const policies: string[] = []
+
+  for (const [tool, restriction] of Object.entries(config.restrictions)) {
+    const fields = Object.entries(restriction.allowedValues)
+    if (fields.length === 0) {
+      // Empty allowedValues = no values are allowed, deny the tool entirely
+      policies.push(
+        `forbid(\n  principal,\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n);`
+      )
+      continue
+    }
+    for (const [field, allowedValues] of fields) {
+      const valueChecks = allowedValues
+        .map((v) => `context.input.${field} == ${JSON.stringify(v)}`)
+        .join(' || ')
+      policies.push(
+        `forbid(\n  principal,\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when {\n  !(context.input has "${escapeCedarString(field)}" && (${valueChecks}))\n};`
+      )
+    }
+  }
+
+  return policies
+}
+
+function generateRateLimitPolicies(config: CedarAgentConfig): string[] {
+  if (!config.rateLimits) return []
+  const policies: string[] = []
+
+  for (const [tool, max] of Object.entries(config.rateLimits)) {
+    policies.push(
+      `forbid(\n  principal,\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= ${max} };`
+    )
+  }
+
+  return policies
+}
+
+function generateTimeWindowPolicy(config: CedarAgentConfig): string[] {
+  if (!config.timeWindow) return []
+  const { hourStart, hourEnd } = config.timeWindow
+  return [
+    `forbid(\n  principal,\n  action,\n  resource\n) when { context.session has "hour_utc" && (context.session.hour_utc < ${hourStart} || context.session.hour_utc >= ${hourEnd}) };`,
+  ]
+}
+
+function generateEnvDenialPolicies(config: CedarAgentConfig): string[] {
+  if (!config.denyInEnv) return []
+  const policies: string[] = []
+
+  for (const [env, tools] of Object.entries(config.denyInEnv)) {
+    if (tools.includes('*')) {
+      // Deny all tools in this environment
+      policies.push(
+        `forbid(\n  principal,\n  action,\n  resource\n) when { context.session has "environment" && context.session.environment == "${escapeCedarString(env)}" };`
+      )
+    } else {
+      for (const tool of tools) {
+        policies.push(
+          `forbid(\n  principal,\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "environment" && context.session.environment == "${escapeCedarString(env)}" };`
+        )
+      }
+    }
+  }
+
+  return policies
+}
+
+function generateConsentPolicies(config: CedarAgentConfig): string[] {
+  if (!config.consent) return []
+  const principalType = config.principal.type ?? 'User'
+  const policies: string[] = []
+
+  for (const [tool, roles] of Object.entries(config.consent)) {
+    if (roles.includes('*')) {
+      // All roles need consent — no role check in the policy
+      policies.push(
+        `permit(\n  principal is ${principalType},\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "user_consent" && context.session.user_consent == true };`
+      )
+    } else {
+      for (const role of roles) {
+        policies.push(
+          `permit(\n  principal is ${principalType},\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(role)}" && context.session has "user_consent" && context.session.user_consent == true };`
+        )
+      }
+    }
+  }
+
+  return policies
+}
+
+export function generatePolicies(config: CedarAgentConfig): string {
+  const allPolicies = [
+    ...generateRolePolicies(config),
+    ...generateRestrictionPolicies(config),
+    ...generateRateLimitPolicies(config),
+    ...generateTimeWindowPolicy(config),
+    ...generateEnvDenialPolicies(config),
+    ...generateConsentPolicies(config),
+  ]
+  return allPolicies.join('\n\n')
+}

--- a/js/cedar-agent-policy-builder/src/policy-generators.ts
+++ b/js/cedar-agent-policy-builder/src/policy-generators.ts
@@ -24,32 +24,28 @@ function getConsentToolsForRole(config: CedarAgentConfig, roleName: string): Set
 function generateRolePolicies(config: CedarAgentConfig): string[] {
   if (!config.roles) return []
   const ns = config.namespace ?? 'Agent'
-  const principalType = config.principal.type ?? 'User'
   const policies: string[] = []
 
   for (const [roleName, tools] of Object.entries(config.roles)) {
     const consentToolsForRole = getConsentToolsForRole(config, roleName)
+    const roleRef = `${ns}::Role::"${escapeCedarString(roleName)}"`
 
     if (tools.includes('*')) {
       if (consentToolsForRole.size > 0) {
-        // Wildcard with consent exclusions: permit all actions EXCEPT consent-gated tools for this role
         const exclusions = [...consentToolsForRole]
           .map((t) => `action == ${ns}::Action::"${escapeCedarString(t)}"`)
           .join(' || ')
         policies.push(
-          `permit(\n  principal is ${ns}::${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" && !(${exclusions}) };`
+          `permit(\n  principal in ${roleRef},\n  action,\n  resource\n) when { !(${exclusions}) };`
         )
       } else {
-        policies.push(
-          `permit(\n  principal is ${ns}::${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
-        )
+        policies.push(`permit(principal in ${roleRef}, action, resource);`)
       }
     } else {
-      // Filter out consent-gated tools for this role — they get their own consent permits
       const filteredTools = tools.filter((t) => !consentToolsForRole.has(t))
       for (const tool of filteredTools) {
         policies.push(
-          `permit(\n  principal is ${ns}::${principalType},\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
+          `permit(principal in ${roleRef}, action == ${ns}::Action::"${escapeCedarString(tool)}", resource);`
         )
       }
     }
@@ -133,20 +129,19 @@ function generateEnvDenialPolicies(config: CedarAgentConfig): string[] {
 function generateConsentPolicies(config: CedarAgentConfig): string[] {
   if (!config.consent) return []
   const ns = config.namespace ?? 'Agent'
-  const principalType = config.principal.type ?? 'User'
   const policies: string[] = []
 
   for (const [tool, value] of Object.entries(config.consent)) {
     const roles = normalizeConsentRoles(value)
     if (roles.includes('*')) {
-      // All roles need consent — no role check in the policy
       policies.push(
-        `permit(\n  principal is ${ns}::${principalType},\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "user_consent" && context.session.user_consent == true };`
+        `permit(\n  principal,\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "user_consent" && context.session.user_consent == true };`
       )
     } else {
       for (const role of roles) {
+        const roleRef = `${ns}::Role::"${escapeCedarString(role)}"`
         policies.push(
-          `permit(\n  principal is ${ns}::${principalType},\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(role)}" && context.session has "user_consent" && context.session.user_consent == true };`
+          `permit(\n  principal in ${roleRef},\n  action == ${ns}::Action::"${escapeCedarString(tool)}",\n  resource\n) when { context.session has "user_consent" && context.session.user_consent == true };`
         )
       }
     }

--- a/js/cedar-agent-policy-builder/src/policy-generators.ts
+++ b/js/cedar-agent-policy-builder/src/policy-generators.ts
@@ -4,18 +4,44 @@ export function escapeCedarString(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
+function getConsentToolsForRole(config: CedarAgentConfig, roleName: string): Set<string> {
+  if (!config.consent) return new Set()
+  const tools = new Set<string>()
+  for (const [tool, roles] of Object.entries(config.consent)) {
+    // Global consent ('*') applies to all roles; role-specific consent only applies to that role
+    if (roles.includes('*') || roles.includes(roleName)) {
+      tools.add(tool)
+    }
+  }
+  return tools
+}
+
 function generateRolePolicies(config: CedarAgentConfig): string[] {
   if (!config.roles) return []
   const principalType = config.principal.type ?? 'User'
   const policies: string[] = []
 
   for (const [roleName, tools] of Object.entries(config.roles)) {
+    const consentToolsForRole = getConsentToolsForRole(config, roleName)
+
     if (tools.includes('*')) {
-      policies.push(
-        `permit(\n  principal is ${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
-      )
+      if (consentToolsForRole.size > 0) {
+        // Wildcard with consent exclusions: permit all actions EXCEPT consent-gated tools for this role
+        const exclusions = [...consentToolsForRole]
+          .map((t) => `action == Action::"${escapeCedarString(t)}"`)
+          .join(' || ')
+        policies.push(
+          `permit(\n  principal is ${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" && !(${exclusions}) };`
+        )
+      } else {
+        policies.push(
+          `permit(\n  principal is ${principalType},\n  action,\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
+        )
+      }
     } else {
-      for (const tool of tools) {
+      // Filter out consent-gated tools for this role — they get their own consent permits
+      const filteredTools = tools.filter((t) => !consentToolsForRole.has(t))
+      for (const tool of filteredTools) {
         policies.push(
           `permit(\n  principal is ${principalType},\n  action == Action::"${escapeCedarString(tool)}",\n  resource\n) when { principal.role == "${escapeCedarString(roleName)}" };`
         )

--- a/js/cedar-agent-policy-builder/src/policy-generators.ts
+++ b/js/cedar-agent-policy-builder/src/policy-generators.ts
@@ -4,11 +4,16 @@ export function escapeCedarString(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
+function normalizeConsentRoles(value: true | string[]): string[] {
+  return value === true ? ['*'] : value
+}
+
 function getConsentToolsForRole(config: CedarAgentConfig, roleName: string): Set<string> {
   if (!config.consent) return new Set()
   const tools = new Set<string>()
-  for (const [tool, roles] of Object.entries(config.consent)) {
-    // Global consent ('*') applies to all roles; role-specific consent only applies to that role
+  for (const [tool, value] of Object.entries(config.consent)) {
+    const roles = normalizeConsentRoles(value)
+    // Global consent ('*' or true) applies to all roles; role-specific consent only applies to that role
     if (roles.includes('*') || roles.includes(roleName)) {
       tools.add(tool)
     }
@@ -126,7 +131,8 @@ function generateConsentPolicies(config: CedarAgentConfig): string[] {
   const principalType = config.principal.type ?? 'User'
   const policies: string[] = []
 
-  for (const [tool, roles] of Object.entries(config.consent)) {
+  for (const [tool, value] of Object.entries(config.consent)) {
+    const roles = normalizeConsentRoles(value)
     if (roles.includes('*')) {
       // All roles need consent — no role check in the policy
       policies.push(

--- a/js/cedar-agent-policy-builder/src/schema.ts
+++ b/js/cedar-agent-policy-builder/src/schema.ts
@@ -4,7 +4,7 @@ import { generateSchema as generateSchemaWasm } from '@cedar-policy/mcp-schema-g
 function buildSchemaStub(config: CedarAgentConfig): string {
   const ns = config.namespace ?? 'Agent'
   const principalType = config.principal.type ?? 'User'
-  const resourceType = config.resource?.type ?? 'McpServer'
+  const resourceType = config.resource?.type ?? 'Resource'
 
   return `namespace ${ns} {
   entity Role;

--- a/js/cedar-agent-policy-builder/src/schema.ts
+++ b/js/cedar-agent-policy-builder/src/schema.ts
@@ -8,7 +8,9 @@ function buildSchemaStub(config: CedarAgentConfig): string {
 
   return `namespace ${ns} {
   @mcp_principal("${principalType}")
-  entity ${principalType};
+  entity ${principalType} = {
+    role: String,
+  };
 
   @mcp_resource("${resourceType}")
   entity ${resourceType};
@@ -37,5 +39,9 @@ export function generateSchema(config: CedarAgentConfig): string | undefined {
     throw new Error(`Schema generation failed: ${result.error}`)
   }
 
-  return result.schema
+  // Strip the namespace wrapper so policies don't need namespace-qualified action names.
+  // The schema generator outputs `namespace Agent { ... }` but our policies use `Action::"search"`,
+  // not `Agent::Action::"search"`. Stripping the namespace makes validation work.
+  const schema: string = result.schema
+  return schema.replace(/^namespace\s+[\w:]+\s*\{/, '').replace(/\}\s*$/, '').trim()
 }

--- a/js/cedar-agent-policy-builder/src/schema.ts
+++ b/js/cedar-agent-policy-builder/src/schema.ts
@@ -7,10 +7,10 @@ function buildSchemaStub(config: CedarAgentConfig): string {
   const resourceType = config.resource?.type ?? 'McpServer'
 
   return `namespace ${ns} {
+  entity Role;
+
   @mcp_principal("${principalType}")
-  entity ${principalType} = {
-    role: String,
-  };
+  entity ${principalType} in [Role];
 
   @mcp_resource("${resourceType}")
   entity ${resourceType};

--- a/js/cedar-agent-policy-builder/src/schema.ts
+++ b/js/cedar-agent-policy-builder/src/schema.ts
@@ -1,0 +1,41 @@
+import type { CedarAgentConfig } from './types.js'
+import { generateSchema as generateSchemaWasm } from '@cedar-policy/mcp-schema-generator-wasm'
+
+function buildSchemaStub(config: CedarAgentConfig): string {
+  const ns = config.namespace ?? 'Agent'
+  const principalType = config.principal.type ?? 'User'
+  const resourceType = config.resource?.type ?? 'McpServer'
+
+  return `namespace ${ns} {
+  @mcp_principal("${principalType}")
+  entity ${principalType};
+
+  @mcp_resource("${resourceType}")
+  entity ${resourceType};
+}`
+}
+
+function buildToolsJson(config: CedarAgentConfig): string {
+  const tools = (config.tools ?? []).map((t) => ({
+    name: t.name,
+    description: t.description ?? '',
+    inputSchema: t.inputSchema,
+    ...(t.outputSchema ? { outputSchema: t.outputSchema } : {}),
+  }))
+  return JSON.stringify({ result: { tools } })
+}
+
+export function generateSchema(config: CedarAgentConfig): string | undefined {
+  if (!config.tools || config.tools.length === 0) return undefined
+
+  const schemaStub = buildSchemaStub(config)
+  const toolsJson = buildToolsJson(config)
+  const raw = generateSchemaWasm(schemaStub, toolsJson, '{}')
+  const result = typeof raw === 'string' ? JSON.parse(raw) : raw
+
+  if (!result.isOk) {
+    throw new Error(`Schema generation failed: ${result.error}`)
+  }
+
+  return result.schema
+}

--- a/js/cedar-agent-policy-builder/src/schema.ts
+++ b/js/cedar-agent-policy-builder/src/schema.ts
@@ -39,9 +39,5 @@ export function generateSchema(config: CedarAgentConfig): string | undefined {
     throw new Error(`Schema generation failed: ${result.error}`)
   }
 
-  // Strip the namespace wrapper so policies don't need namespace-qualified action names.
-  // The schema generator outputs `namespace Agent { ... }` but our policies use `Action::"search"`,
-  // not `Agent::Action::"search"`. Stripping the namespace makes validation work.
-  const schema: string = result.schema
-  return schema.replace(/^namespace\s+[\w:]+\s*\{/, '').replace(/\}\s*$/, '').trim()
+  return result.schema
 }

--- a/js/cedar-agent-policy-builder/src/types.ts
+++ b/js/cedar-agent-policy-builder/src/types.ts
@@ -24,6 +24,7 @@ export interface SchemaConfig {
 export interface CedarAgentConfig {
   principal: PrincipalConfig
   roles?: Record<string, string[]>
+  users?: Record<string, string[]>
   restrictions?: Record<string, {
     allowedValues: Record<string, unknown[]>
   }>

--- a/js/cedar-agent-policy-builder/src/types.ts
+++ b/js/cedar-agent-policy-builder/src/types.ts
@@ -30,7 +30,7 @@ export interface CedarAgentConfig {
   rateLimits?: Record<string, number>
   timeWindow?: { hourStart: number; hourEnd: number }
   denyInEnv?: Record<string, string[]>
-  consent?: Record<string, string[]>
+  consent?: Record<string, true | string[]>
   resource?: { type: string; id: string }
   tools?: McpToolDefinition[]
   namespace?: string

--- a/js/cedar-agent-policy-builder/src/types.ts
+++ b/js/cedar-agent-policy-builder/src/types.ts
@@ -1,0 +1,36 @@
+import type { EntityJson, TypeAndId, CedarValueJson } from '@cedar-policy/cedar-wasm'
+
+export type { EntityJson, TypeAndId, CedarValueJson }
+
+export interface PrincipalConfig {
+  key: string
+  type?: string
+}
+
+export interface McpToolDefinition {
+  name: string
+  description?: string
+  inputSchema: Record<string, unknown>
+  outputSchema?: Record<string, unknown>
+}
+
+export interface CedarAgentConfig {
+  principal: PrincipalConfig
+  roles?: Record<string, string[]>
+  restrictions?: Record<string, {
+    allowedValues: Record<string, unknown[]>
+  }>
+  rateLimits?: Record<string, number>
+  timeWindow?: { hourStart: number; hourEnd: number }
+  denyInEnv?: Record<string, string[]>
+  consent?: Record<string, string[]>
+  resource?: { type: string; id: string }
+  tools?: McpToolDefinition[]
+  namespace?: string
+}
+
+export interface BuildResult {
+  policies: string
+  entities: EntityJson[]
+  schema?: string
+}

--- a/js/cedar-agent-policy-builder/src/types.ts
+++ b/js/cedar-agent-policy-builder/src/types.ts
@@ -36,8 +36,21 @@ export interface CedarAgentConfig {
   namespace?: string
 }
 
+export interface ValidationError {
+  policyId: string
+  message: string
+  help?: string
+}
+
+export interface ValidationResult {
+  valid: boolean
+  errors: ValidationError[]
+  warnings: ValidationError[]
+}
+
 export interface BuildResult {
   policies: string
   entities: EntityJson[]
   schema?: string
+  validate(): ValidationResult
 }

--- a/js/cedar-agent-policy-builder/src/types.ts
+++ b/js/cedar-agent-policy-builder/src/types.ts
@@ -14,6 +14,13 @@ export interface McpToolDefinition {
   outputSchema?: Record<string, unknown>
 }
 
+export interface SchemaConfig {
+  principal?: PrincipalConfig
+  resource?: { type: string; id: string }
+  tools?: McpToolDefinition[]
+  namespace?: string
+}
+
 export interface CedarAgentConfig {
   principal: PrincipalConfig
   roles?: Record<string, string[]>

--- a/js/cedar-agent-policy-builder/tests/adversarial.test.ts
+++ b/js/cedar-agent-policy-builder/tests/adversarial.test.ts
@@ -34,7 +34,7 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
     })
     const result = authorize({
       policies,
-      entities: [{ uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] }],
+      entities: [{ uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin' }] }],
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'tool"; forbid(principal, action, resource);// ',
       resource: { type: 'Agent::McpServer', id: 'agent' },
@@ -51,7 +51,7 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
     const result = authorize({
       policies,
       entities: [
-        { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin"; permit(principal, action, resource);//' }, parents: [] },
+        { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin"; permit(principal, action, resource);//' }] },
       ],
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
@@ -68,7 +68,7 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
     })
     const result = authorize({
       policies,
-      entities: [{ uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] }],
+      entities: [{ uid: { type: 'Agent::User', id: 'a' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'user' }] }],
       principal: { type: 'Agent::User', id: 'a' },
       action: 'tool\\',
       resource: { type: 'Agent::McpServer', id: 'agent' },
@@ -89,7 +89,7 @@ describe('adversarial: deny-by-default behavior', () => {
       policies,
       entities: [
         ...entities,
-        { uid: { type: 'Agent::User', id: 'unknown' }, attrs: { role: 'unknown_role' }, parents: [] },
+        { uid: { type: 'Agent::User', id: 'unknown' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'unknown_role' }] },
       ],
       principal: { type: 'Agent::User', id: 'unknown' },
       action: 'search',
@@ -99,7 +99,7 @@ describe('adversarial: deny-by-default behavior', () => {
     expect(result.decision).toBe('deny')
   })
 
-  it('user with no role attribute is denied', () => {
+  it('user with no role parent is denied', () => {
     const { policies, entities } = fromConfig({
       principal: { key: 'user_id', type: 'User' },
       roles: { admin: ['*'] },
@@ -115,7 +115,6 @@ describe('adversarial: deny-by-default behavior', () => {
       resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
-    // Cedar will error on accessing .role on entity without it, which results in deny
     expect(result.decision).not.toBe('allow')
   })
 
@@ -128,7 +127,7 @@ describe('adversarial: deny-by-default behavior', () => {
       policies,
       entities: [
         ...entities,
-        { uid: { type: 'Hacker', id: 'evil' }, attrs: { role: 'admin' }, parents: [] },
+        { uid: { type: 'Hacker', id: 'evil' }, attrs: {}, parents: [] },
       ],
       principal: { type: 'Hacker', id: 'evil' },
       action: 'search',
@@ -150,7 +149,7 @@ describe('adversarial: restriction bypass attempts', () => {
 
   const userEntities = [
     ...entities,
-    { uid: { type: 'Agent::User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] },
+    { uid: { type: 'Agent::User', id: 'bob' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'analyst' }] },
   ]
 
   it('missing input field triggers denial (has guard catches it)', () => {
@@ -225,7 +224,7 @@ describe('adversarial: rate limit boundary conditions', () => {
 
   const userEntities = [
     ...entities,
-    { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'user' }, parents: [] },
+    { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'user' }] },
   ]
 
   it('call_count of 0 is allowed', () => {
@@ -313,7 +312,7 @@ describe('adversarial: time window edge cases', () => {
 
   const userEntities = [
     ...entities,
-    { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'user' }, parents: [] },
+    { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'user' }] },
   ]
 
   it('hour 9 (start boundary) is allowed', () => {
@@ -398,7 +397,7 @@ describe('adversarial: environment denial bypass attempts', () => {
 
   const userEntities = [
     ...entities,
-    { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+    { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin' }] },
   ]
 
   it('case-different environment name does not trigger denial', () => {
@@ -449,7 +448,7 @@ describe('adversarial: policy interaction / precedence', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin' }] },
     ]
     const result = authorize({
       policies,
@@ -472,7 +471,7 @@ describe('adversarial: policy interaction / precedence', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin' }] },
     ]
     // Denied by time window alone
     const result1 = authorize({
@@ -506,7 +505,7 @@ describe('adversarial: unicode and special characters', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'Agent::User', id: 'tanaka' }, attrs: { role: '管理者' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'tanaka' }, attrs: {}, parents: [{ type: 'Agent::Role', id: '管理者' }] },
     ]
     const result = authorize({
       policies,
@@ -526,7 +525,7 @@ describe('adversarial: unicode and special characters', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'a' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'user' }] },
     ]
     const result = authorize({
       policies,
@@ -546,7 +545,7 @@ describe('adversarial: unicode and special characters', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'a' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'user' }] },
     ]
     const result = authorize({
       policies,
@@ -567,7 +566,7 @@ describe('adversarial: empty and degenerate configs', () => {
     })
     expect(policies).toBe('')
     expect(entities).toEqual([
-      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
     ])
     const result = authorize({
       policies,
@@ -588,7 +587,7 @@ describe('adversarial: empty and degenerate configs', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'a' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'user' }] },
     ]
     // call_count >= 0 is always true, so this always denies
     const result = authorize({
@@ -610,7 +609,7 @@ describe('adversarial: empty and degenerate configs', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'a' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'user' }] },
     ]
     // hour < 12 || hour >= 12 is always true → always denied
     const result = authorize({
@@ -632,7 +631,7 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
       .consent(['send_email'])
       .build()
 
-    const allEntities = [...entities, { uid: { type: 'Agent::User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] }]
+    const allEntities = [...entities, { uid: { type: 'Agent::User', id: 'bob' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'analyst' }] }]
 
     // search: allowed (unconditional permit)
     const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'search', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
@@ -653,7 +652,7 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
       .consent(['send_email'])
       .build()
 
-    const allEntities = [...entities, { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] }]
+    const allEntities = [...entities, { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin' }] }]
 
     // other tools: allowed (wildcard minus exclusion)
     const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'delete_record', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
@@ -677,8 +676,8 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
 
     const allEntities = [
       ...entities,
-      { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
-      { uid: { type: 'Agent::User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin' }] },
+      { uid: { type: 'Agent::User', id: 'bob' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'analyst' }] },
     ]
 
     // admin: send_email allowed without consent (no consent gate for admin)

--- a/js/cedar-agent-policy-builder/tests/adversarial.test.ts
+++ b/js/cedar-agent-policy-builder/tests/adversarial.test.ts
@@ -624,3 +624,73 @@ describe('adversarial: empty and degenerate configs', () => {
     expect(result.decision).toBe('deny')
   })
 })
+
+describe('consent enforcement: consent cannot be bypassed by role permits', () => {
+  it('role permit does not bypass consent (auto-exclude)', () => {
+    const { policies, entities } = new CedarAgentPolicyBuilder()
+      .role('analyst', ['search', 'send_email'])
+      .consent(['send_email'])
+      .build()
+
+    const allEntities = [...entities, { uid: { type: 'User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] }]
+
+    // search: allowed (unconditional permit)
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'search', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    expect(r1.decision).toBe('allow')
+
+    // send_email without consent: denied
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    expect(r2.decision).toBe('deny')
+
+    // send_email with consent: allowed
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    expect(r3.decision).toBe('allow')
+  })
+
+  it('wildcard role does not bypass consent', () => {
+    const { policies, entities } = new CedarAgentPolicyBuilder()
+      .role('admin', ['*'])
+      .consent(['send_email'])
+      .build()
+
+    const allEntities = [...entities, { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] }]
+
+    // other tools: allowed (wildcard minus exclusion)
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'alice' }, action: 'delete_record', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    expect(r1.decision).toBe('allow')
+
+    // send_email without consent: denied even for admin
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'alice' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    expect(r2.decision).toBe('deny')
+
+    // send_email with consent: allowed
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'alice' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    expect(r3.decision).toBe('allow')
+  })
+
+  it('role-scoped consent only applies to that role', () => {
+    const { policies, entities } = new CedarAgentPolicyBuilder()
+      .role('admin', ['*'])
+      .role('analyst', ['search', 'send_email'])
+      .consent(['send_email'], 'analyst')
+      .build()
+
+    const allEntities = [
+      ...entities,
+      { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+      { uid: { type: 'User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] },
+    ]
+
+    // admin: send_email allowed without consent (no consent gate for admin)
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'alice' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    expect(r1.decision).toBe('allow')
+
+    // analyst: send_email denied without consent
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    expect(r2.decision).toBe('deny')
+
+    // analyst: send_email allowed with consent
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    expect(r3.decision).toBe('allow')
+  })
+})

--- a/js/cedar-agent-policy-builder/tests/adversarial.test.ts
+++ b/js/cedar-agent-policy-builder/tests/adversarial.test.ts
@@ -37,7 +37,7 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
       entities: [{ uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin' }] }],
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'tool"; forbid(principal, action, resource);// ',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -55,7 +55,7 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
       ],
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -71,7 +71,7 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
       entities: [{ uid: { type: 'Agent::User', id: 'a' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'user' }] }],
       principal: { type: 'Agent::User', id: 'a' },
       action: 'tool\\',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // Should either allow (correct parse) or error (invalid Cedar) — never silently permit everything
@@ -93,7 +93,7 @@ describe('adversarial: deny-by-default behavior', () => {
       ],
       principal: { type: 'Agent::User', id: 'unknown' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -112,7 +112,7 @@ describe('adversarial: deny-by-default behavior', () => {
       ],
       principal: { type: 'Agent::User', id: 'norole' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).not.toBe('allow')
@@ -131,7 +131,7 @@ describe('adversarial: deny-by-default behavior', () => {
       ],
       principal: { type: 'Hacker', id: 'evil' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -158,7 +158,7 @@ describe('adversarial: restriction bypass attempts', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // The `has` guard makes this safe: context.input has "database" → false
@@ -172,7 +172,7 @@ describe('adversarial: restriction bypass attempts', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: { database: null }, session: {} },
     })
     expect(result.decision).not.toBe('allow')
@@ -184,7 +184,7 @@ describe('adversarial: restriction bypass attempts', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: { database: 123 }, session: {} },
     })
     expect(result.decision).not.toBe('allow')
@@ -196,7 +196,7 @@ describe('adversarial: restriction bypass attempts', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: { database: 'Analytics' }, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -208,7 +208,7 @@ describe('adversarial: restriction bypass attempts', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: { database: 'analytics ' }, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -233,7 +233,7 @@ describe('adversarial: rate limit boundary conditions', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { call_count: 0 } },
     })
     expect(result.decision).toBe('allow')
@@ -245,7 +245,7 @@ describe('adversarial: rate limit boundary conditions', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { call_count: 2 } },
     })
     expect(result.decision).toBe('allow')
@@ -257,7 +257,7 @@ describe('adversarial: rate limit boundary conditions', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { call_count: 3 } },
     })
     expect(result.decision).toBe('deny')
@@ -269,7 +269,7 @@ describe('adversarial: rate limit boundary conditions', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { call_count: 999999 } },
     })
     expect(result.decision).toBe('deny')
@@ -281,7 +281,7 @@ describe('adversarial: rate limit boundary conditions', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { call_count: -1 } },
     })
     expect(result.decision).toBe('allow')
@@ -293,7 +293,7 @@ describe('adversarial: rate limit boundary conditions', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // Cedar errors on accessing missing attr → forbid policy errors out → no forbid effect → allow
@@ -321,7 +321,7 @@ describe('adversarial: time window edge cases', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 9 } },
     })
     expect(result.decision).toBe('allow')
@@ -333,7 +333,7 @@ describe('adversarial: time window edge cases', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 16 } },
     })
     expect(result.decision).toBe('allow')
@@ -345,7 +345,7 @@ describe('adversarial: time window edge cases', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 17 } },
     })
     expect(result.decision).toBe('deny')
@@ -357,7 +357,7 @@ describe('adversarial: time window edge cases', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 8 } },
     })
     expect(result.decision).toBe('deny')
@@ -369,7 +369,7 @@ describe('adversarial: time window edge cases', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 0 } },
     })
     expect(result.decision).toBe('deny')
@@ -381,7 +381,7 @@ describe('adversarial: time window edge cases', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 23 } },
     })
     expect(result.decision).toBe('deny')
@@ -406,7 +406,7 @@ describe('adversarial: environment denial bypass attempts', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'delete_record',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { environment: 'Production' } },
     })
     // "Production" != "production" — forbid doesn't fire, so allow stands
@@ -419,7 +419,7 @@ describe('adversarial: environment denial bypass attempts', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'delete_record',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { environment: '' } },
     })
     expect(result.decision).toBe('allow')
@@ -431,7 +431,7 @@ describe('adversarial: environment denial bypass attempts', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'delete_record',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // Cedar errors accessing missing field → forbid errors out → no forbid → allow
@@ -455,7 +455,7 @@ describe('adversarial: policy interaction / precedence', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { call_count: 5 } },
     })
     // Even though admin has wildcard permit, the rate limit forbid wins
@@ -479,7 +479,7 @@ describe('adversarial: policy interaction / precedence', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 2, environment: 'staging' } },
     })
     expect(result1.decision).toBe('deny')
@@ -490,7 +490,7 @@ describe('adversarial: policy interaction / precedence', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'alice' },
       action: 'delete_record',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 10, environment: 'production' } },
     })
     expect(result2.decision).toBe('deny')
@@ -512,7 +512,7 @@ describe('adversarial: unicode and special characters', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'tanaka' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -532,7 +532,7 @@ describe('adversarial: unicode and special characters', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'a' },
       action: '🔍search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -552,7 +552,7 @@ describe('adversarial: unicode and special characters', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'a' },
       action: '',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -566,14 +566,14 @@ describe('adversarial: empty and degenerate configs', () => {
     })
     expect(policies).toBe('')
     expect(entities).toEqual([
-      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Resource', id: 'default' }, attrs: {}, parents: [] },
     ])
     const result = authorize({
       policies,
       entities: [{ uid: { type: 'Agent::User', id: 'a' }, attrs: {}, parents: [] }],
       principal: { type: 'Agent::User', id: 'a' },
       action: 'anything',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -595,7 +595,7 @@ describe('adversarial: empty and degenerate configs', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'a' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { call_count: 0 } },
     })
     expect(result.decision).toBe('deny')
@@ -617,7 +617,7 @@ describe('adversarial: empty and degenerate configs', () => {
       entities: userEntities,
       principal: { type: 'Agent::User', id: 'a' },
       action: 'search',
-      resource: { type: 'Agent::McpServer', id: 'agent' },
+      resource: { type: 'Agent::Resource', id: 'agent' },
       context: { input: {}, session: { hour_utc: 12 } },
     })
     expect(result.decision).toBe('deny')
@@ -634,15 +634,15 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
     const allEntities = [...entities, { uid: { type: 'Agent::User', id: 'bob' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'analyst' }] }]
 
     // search: allowed (unconditional permit)
-    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'search', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'search', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: {} } })
     expect(r1.decision).toBe('allow')
 
     // send_email without consent: denied
-    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: {} } })
     expect(r2.decision).toBe('deny')
 
     // send_email with consent: allowed
-    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
     expect(r3.decision).toBe('allow')
   })
 
@@ -655,15 +655,15 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
     const allEntities = [...entities, { uid: { type: 'Agent::User', id: 'alice' }, attrs: {}, parents: [{ type: 'Agent::Role', id: 'admin' }] }]
 
     // other tools: allowed (wildcard minus exclusion)
-    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'delete_record', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'delete_record', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: {} } })
     expect(r1.decision).toBe('allow')
 
     // send_email without consent: denied even for admin
-    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: {} } })
     expect(r2.decision).toBe('deny')
 
     // send_email with consent: allowed
-    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
     expect(r3.decision).toBe('allow')
   })
 
@@ -681,15 +681,15 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
     ]
 
     // admin: send_email allowed without consent (no consent gate for admin)
-    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: {} } })
     expect(r1.decision).toBe('allow')
 
     // analyst: send_email denied without consent
-    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: {} } })
     expect(r2.decision).toBe('deny')
 
     // analyst: send_email allowed with consent
-    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::Resource', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
     expect(r3.decision).toBe('allow')
   })
 })

--- a/js/cedar-agent-policy-builder/tests/adversarial.test.ts
+++ b/js/cedar-agent-policy-builder/tests/adversarial.test.ts
@@ -1,0 +1,626 @@
+import { describe, it, expect } from 'vitest'
+import { isAuthorized } from '@cedar-policy/cedar-wasm/nodejs'
+import { CedarAgentPolicyBuilder, fromConfig } from '../src/index.js'
+import { generatePolicies } from '../src/policy-generators.js'
+import type { CedarAgentConfig } from '../src/types.js'
+
+function authorize(opts: {
+  policies: string
+  entities: Array<{ uid: { type: string; id: string }; attrs: Record<string, unknown>; parents: Array<{ type: string; id: string }> }>
+  principal: { type: string; id: string }
+  action: string
+  resource: { type: string; id: string }
+  context: Record<string, unknown>
+}) {
+  const result = isAuthorized({
+    principal: opts.principal,
+    action: { type: 'Action', id: opts.action },
+    resource: opts.resource,
+    context: opts.context,
+    policies: { staticPolicies: opts.policies },
+    entities: opts.entities as any,
+  })
+  if (result.type === 'failure') {
+    return { decision: 'error' as const, errors: result.errors }
+  }
+  return { decision: result.response.decision }
+}
+
+describe('adversarial: Cedar syntax injection via tool names', () => {
+  it('tool name with quotes does not break policy syntax', () => {
+    const { policies } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { admin: ['tool"; forbid(principal, action, resource);// '] },
+    })
+    const result = authorize({
+      policies,
+      entities: [{ uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] }],
+      principal: { type: 'User', id: 'alice' },
+      action: 'tool"; forbid(principal, action, resource);// ',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('role name with quotes does not inject policies', () => {
+    const { policies } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { 'admin"; permit(principal, action, resource);//': ['search'] },
+    })
+    const result = authorize({
+      policies,
+      entities: [
+        { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin"; permit(principal, action, resource);//' }, parents: [] },
+      ],
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('backslash sequences in tool names are handled safely', () => {
+    const { policies } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { user: ['tool\\","evil'] },
+    })
+    const result = authorize({
+      policies,
+      entities: [{ uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] }],
+      principal: { type: 'User', id: 'a' },
+      action: 'tool\\',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    // Should either allow (correct parse) or error (invalid Cedar) — never silently permit everything
+    expect(result.decision).not.toBe('error')
+  })
+})
+
+describe('adversarial: deny-by-default behavior', () => {
+  it('unknown user with no matching role is denied', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { admin: ['*'] },
+    })
+    const result = authorize({
+      policies,
+      entities: [
+        ...entities,
+        { uid: { type: 'User', id: 'unknown' }, attrs: { role: 'unknown_role' }, parents: [] },
+      ],
+      principal: { type: 'User', id: 'unknown' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('user with no role attribute is denied', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { admin: ['*'] },
+    })
+    const result = authorize({
+      policies,
+      entities: [
+        ...entities,
+        { uid: { type: 'User', id: 'norole' }, attrs: {}, parents: [] },
+      ],
+      principal: { type: 'User', id: 'norole' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    // Cedar will error on accessing .role on entity without it, which results in deny
+    expect(result.decision).not.toBe('allow')
+  })
+
+  it('completely unknown principal type is denied', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { admin: ['search'] },
+    })
+    const result = authorize({
+      policies,
+      entities: [
+        ...entities,
+        { uid: { type: 'Hacker', id: 'evil' }, attrs: { role: 'admin' }, parents: [] },
+      ],
+      principal: { type: 'Hacker', id: 'evil' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    expect(result.decision).toBe('deny')
+  })
+})
+
+describe('adversarial: restriction bypass attempts', () => {
+  const { policies, entities } = fromConfig({
+    principal: { key: 'user_id', type: 'User' },
+    roles: { analyst: ['query_database'] },
+    restrictions: {
+      query_database: { allowedValues: { database: ['analytics', 'reporting'] } },
+    },
+  })
+
+  const userEntities = [
+    ...entities,
+    { uid: { type: 'User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] },
+  ]
+
+  it('missing input field triggers denial (has guard catches it)', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'bob' },
+      action: 'query_database',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    // The `has` guard makes this safe: context.input has "database" → false
+    // !(false && ...) → !(false) → true → forbid fires → DENY
+    expect(result.decision).toBe('deny')
+  })
+
+  it('null input value is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'bob' },
+      action: 'query_database',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: { database: null }, session: {} },
+    })
+    expect(result.decision).not.toBe('allow')
+  })
+
+  it('numeric input where string expected is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'bob' },
+      action: 'query_database',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: { database: 123 }, session: {} },
+    })
+    expect(result.decision).not.toBe('allow')
+  })
+
+  it('case-different value is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'bob' },
+      action: 'query_database',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: { database: 'Analytics' }, session: {} },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('value with trailing space is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'bob' },
+      action: 'query_database',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: { database: 'analytics ' }, session: {} },
+    })
+    expect(result.decision).toBe('deny')
+  })
+})
+
+describe('adversarial: rate limit boundary conditions', () => {
+  const { policies, entities } = fromConfig({
+    principal: { key: 'user_id', type: 'User' },
+    roles: { user: ['send_email'] },
+    rateLimits: { send_email: 3 },
+  })
+
+  const userEntities = [
+    ...entities,
+    { uid: { type: 'User', id: 'alice' }, attrs: { role: 'user' }, parents: [] },
+  ]
+
+  it('call_count of 0 is allowed', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'send_email',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { call_count: 0 } },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('call_count just below limit (2) is allowed', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'send_email',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { call_count: 2 } },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('call_count exactly at limit (3) is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'send_email',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { call_count: 3 } },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('very large call_count is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'send_email',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { call_count: 999999 } },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('negative call_count is allowed (under limit)', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'send_email',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { call_count: -1 } },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('missing call_count does not bypass rate limit (errors → deny)', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'send_email',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    // Cedar errors on accessing missing attr → forbid policy errors out → no forbid effect → allow
+    // This is a known gap: if session.call_count is missing, the forbid doesn't fire
+    // Document the actual behavior
+    expect(['allow', 'deny']).toContain(result.decision)
+  })
+})
+
+describe('adversarial: time window edge cases', () => {
+  const { policies, entities } = fromConfig({
+    principal: { key: 'user_id', type: 'User' },
+    roles: { user: ['search'] },
+    timeWindow: { hourStart: 9, hourEnd: 17 },
+  })
+
+  const userEntities = [
+    ...entities,
+    { uid: { type: 'User', id: 'alice' }, attrs: { role: 'user' }, parents: [] },
+  ]
+
+  it('hour 9 (start boundary) is allowed', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 9 } },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('hour 16 (last allowed hour) is allowed', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 16 } },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('hour 17 (end boundary) is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 17 } },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('hour 8 (just before start) is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 8 } },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('hour 0 (midnight) is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 0 } },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('hour 23 is denied', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 23 } },
+    })
+    expect(result.decision).toBe('deny')
+  })
+})
+
+describe('adversarial: environment denial bypass attempts', () => {
+  const { policies, entities } = fromConfig({
+    principal: { key: 'user_id', type: 'User' },
+    roles: { admin: ['*'] },
+    denyInEnv: { production: ['delete_record'] },
+  })
+
+  const userEntities = [
+    ...entities,
+    { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+  ]
+
+  it('case-different environment name does not trigger denial', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'delete_record',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { environment: 'Production' } },
+    })
+    // "Production" != "production" — forbid doesn't fire, so allow stands
+    expect(result.decision).toBe('allow')
+  })
+
+  it('empty environment string does not trigger denial', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'delete_record',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { environment: '' } },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('missing environment field does not trigger denial (allows action)', () => {
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'delete_record',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    // Cedar errors accessing missing field → forbid errors out → no forbid → allow
+    expect(result.decision).toBe('allow')
+  })
+})
+
+describe('adversarial: policy interaction / precedence', () => {
+  it('forbid overrides permit (Cedar default semantics)', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { admin: ['*'] },
+      rateLimits: { search: 1 },
+    })
+    const userEntities = [
+      ...entities,
+      { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+    ]
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { call_count: 5 } },
+    })
+    // Even though admin has wildcard permit, the rate limit forbid wins
+    expect(result.decision).toBe('deny')
+  })
+
+  it('multiple forbid conditions all apply independently', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { admin: ['*'] },
+      timeWindow: { hourStart: 9, hourEnd: 17 },
+      denyInEnv: { production: ['delete_record'] },
+    })
+    const userEntities = [
+      ...entities,
+      { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+    ]
+    // Denied by time window alone
+    const result1 = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 2, environment: 'staging' } },
+    })
+    expect(result1.decision).toBe('deny')
+
+    // Denied by env denial alone
+    const result2 = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'alice' },
+      action: 'delete_record',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 10, environment: 'production' } },
+    })
+    expect(result2.decision).toBe('deny')
+  })
+})
+
+describe('adversarial: unicode and special characters', () => {
+  it('unicode role names work correctly', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { '管理者': ['search'] },
+    })
+    const userEntities = [
+      ...entities,
+      { uid: { type: 'User', id: 'tanaka' }, attrs: { role: '管理者' }, parents: [] },
+    ]
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'tanaka' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('emoji in tool names', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { user: ['🔍search'] },
+    })
+    const userEntities = [
+      ...entities,
+      { uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+    ]
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'a' },
+      action: '🔍search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    expect(result.decision).toBe('allow')
+  })
+
+  it('empty string tool name', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { user: [''] },
+    })
+    const userEntities = [
+      ...entities,
+      { uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+    ]
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'a' },
+      action: '',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    expect(result.decision).toBe('allow')
+  })
+})
+
+describe('adversarial: empty and degenerate configs', () => {
+  it('no roles means everything is denied', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+    })
+    expect(policies).toBe('')
+    expect(entities).toEqual([
+      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+    ])
+    const result = authorize({
+      policies,
+      entities: [{ uid: { type: 'User', id: 'a' }, attrs: {}, parents: [] }],
+      principal: { type: 'User', id: 'a' },
+      action: 'anything',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: {} },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('role with zero-length rate limit allows unlimited calls', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { user: ['search'] },
+      rateLimits: { search: 0 },
+    })
+    const userEntities = [
+      ...entities,
+      { uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+    ]
+    // call_count >= 0 is always true, so this always denies
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'a' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { call_count: 0 } },
+    })
+    expect(result.decision).toBe('deny')
+  })
+
+  it('time window hourStart == hourEnd denies all hours', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { user: ['search'] },
+      timeWindow: { hourStart: 12, hourEnd: 12 },
+    })
+    const userEntities = [
+      ...entities,
+      { uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+    ]
+    // hour < 12 || hour >= 12 is always true → always denied
+    const result = authorize({
+      policies,
+      entities: userEntities,
+      principal: { type: 'User', id: 'a' },
+      action: 'search',
+      resource: { type: 'Resource', id: 'agent' },
+      context: { input: {}, session: { hour_utc: 12 } },
+    })
+    expect(result.decision).toBe('deny')
+  })
+})

--- a/js/cedar-agent-policy-builder/tests/adversarial.test.ts
+++ b/js/cedar-agent-policy-builder/tests/adversarial.test.ts
@@ -14,7 +14,7 @@ function authorize(opts: {
 }) {
   const result = isAuthorized({
     principal: opts.principal,
-    action: { type: 'Action', id: opts.action },
+    action: { type: 'Agent::Action', id: opts.action },
     resource: opts.resource,
     context: opts.context,
     policies: { staticPolicies: opts.policies },
@@ -34,10 +34,10 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
     })
     const result = authorize({
       policies,
-      entities: [{ uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] }],
-      principal: { type: 'User', id: 'alice' },
+      entities: [{ uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] }],
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'tool"; forbid(principal, action, resource);// ',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -51,11 +51,11 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
     const result = authorize({
       policies,
       entities: [
-        { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin"; permit(principal, action, resource);//' }, parents: [] },
+        { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin"; permit(principal, action, resource);//' }, parents: [] },
       ],
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -68,10 +68,10 @@ describe('adversarial: Cedar syntax injection via tool names', () => {
     })
     const result = authorize({
       policies,
-      entities: [{ uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] }],
-      principal: { type: 'User', id: 'a' },
+      entities: [{ uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] }],
+      principal: { type: 'Agent::User', id: 'a' },
       action: 'tool\\',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // Should either allow (correct parse) or error (invalid Cedar) — never silently permit everything
@@ -89,11 +89,11 @@ describe('adversarial: deny-by-default behavior', () => {
       policies,
       entities: [
         ...entities,
-        { uid: { type: 'User', id: 'unknown' }, attrs: { role: 'unknown_role' }, parents: [] },
+        { uid: { type: 'Agent::User', id: 'unknown' }, attrs: { role: 'unknown_role' }, parents: [] },
       ],
-      principal: { type: 'User', id: 'unknown' },
+      principal: { type: 'Agent::User', id: 'unknown' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -108,11 +108,11 @@ describe('adversarial: deny-by-default behavior', () => {
       policies,
       entities: [
         ...entities,
-        { uid: { type: 'User', id: 'norole' }, attrs: {}, parents: [] },
+        { uid: { type: 'Agent::User', id: 'norole' }, attrs: {}, parents: [] },
       ],
-      principal: { type: 'User', id: 'norole' },
+      principal: { type: 'Agent::User', id: 'norole' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // Cedar will error on accessing .role on entity without it, which results in deny
@@ -132,7 +132,7 @@ describe('adversarial: deny-by-default behavior', () => {
       ],
       principal: { type: 'Hacker', id: 'evil' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -150,16 +150,16 @@ describe('adversarial: restriction bypass attempts', () => {
 
   const userEntities = [
     ...entities,
-    { uid: { type: 'User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] },
+    { uid: { type: 'Agent::User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] },
   ]
 
   it('missing input field triggers denial (has guard catches it)', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'bob' },
+      principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // The `has` guard makes this safe: context.input has "database" → false
@@ -171,9 +171,9 @@ describe('adversarial: restriction bypass attempts', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'bob' },
+      principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: { database: null }, session: {} },
     })
     expect(result.decision).not.toBe('allow')
@@ -183,9 +183,9 @@ describe('adversarial: restriction bypass attempts', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'bob' },
+      principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: { database: 123 }, session: {} },
     })
     expect(result.decision).not.toBe('allow')
@@ -195,9 +195,9 @@ describe('adversarial: restriction bypass attempts', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'bob' },
+      principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: { database: 'Analytics' }, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -207,9 +207,9 @@ describe('adversarial: restriction bypass attempts', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'bob' },
+      principal: { type: 'Agent::User', id: 'bob' },
       action: 'query_database',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: { database: 'analytics ' }, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -225,16 +225,16 @@ describe('adversarial: rate limit boundary conditions', () => {
 
   const userEntities = [
     ...entities,
-    { uid: { type: 'User', id: 'alice' }, attrs: { role: 'user' }, parents: [] },
+    { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'user' }, parents: [] },
   ]
 
   it('call_count of 0 is allowed', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { call_count: 0 } },
     })
     expect(result.decision).toBe('allow')
@@ -244,9 +244,9 @@ describe('adversarial: rate limit boundary conditions', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { call_count: 2 } },
     })
     expect(result.decision).toBe('allow')
@@ -256,9 +256,9 @@ describe('adversarial: rate limit boundary conditions', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { call_count: 3 } },
     })
     expect(result.decision).toBe('deny')
@@ -268,9 +268,9 @@ describe('adversarial: rate limit boundary conditions', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { call_count: 999999 } },
     })
     expect(result.decision).toBe('deny')
@@ -280,9 +280,9 @@ describe('adversarial: rate limit boundary conditions', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { call_count: -1 } },
     })
     expect(result.decision).toBe('allow')
@@ -292,9 +292,9 @@ describe('adversarial: rate limit boundary conditions', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'send_email',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // Cedar errors on accessing missing attr → forbid policy errors out → no forbid effect → allow
@@ -313,16 +313,16 @@ describe('adversarial: time window edge cases', () => {
 
   const userEntities = [
     ...entities,
-    { uid: { type: 'User', id: 'alice' }, attrs: { role: 'user' }, parents: [] },
+    { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'user' }, parents: [] },
   ]
 
   it('hour 9 (start boundary) is allowed', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 9 } },
     })
     expect(result.decision).toBe('allow')
@@ -332,9 +332,9 @@ describe('adversarial: time window edge cases', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 16 } },
     })
     expect(result.decision).toBe('allow')
@@ -344,9 +344,9 @@ describe('adversarial: time window edge cases', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 17 } },
     })
     expect(result.decision).toBe('deny')
@@ -356,9 +356,9 @@ describe('adversarial: time window edge cases', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 8 } },
     })
     expect(result.decision).toBe('deny')
@@ -368,9 +368,9 @@ describe('adversarial: time window edge cases', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 0 } },
     })
     expect(result.decision).toBe('deny')
@@ -380,9 +380,9 @@ describe('adversarial: time window edge cases', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 23 } },
     })
     expect(result.decision).toBe('deny')
@@ -398,16 +398,16 @@ describe('adversarial: environment denial bypass attempts', () => {
 
   const userEntities = [
     ...entities,
-    { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+    { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
   ]
 
   it('case-different environment name does not trigger denial', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'delete_record',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { environment: 'Production' } },
     })
     // "Production" != "production" — forbid doesn't fire, so allow stands
@@ -418,9 +418,9 @@ describe('adversarial: environment denial bypass attempts', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'delete_record',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { environment: '' } },
     })
     expect(result.decision).toBe('allow')
@@ -430,9 +430,9 @@ describe('adversarial: environment denial bypass attempts', () => {
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'delete_record',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     // Cedar errors accessing missing field → forbid errors out → no forbid → allow
@@ -449,14 +449,14 @@ describe('adversarial: policy interaction / precedence', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
     ]
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { call_count: 5 } },
     })
     // Even though admin has wildcard permit, the rate limit forbid wins
@@ -472,15 +472,15 @@ describe('adversarial: policy interaction / precedence', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
     ]
     // Denied by time window alone
     const result1 = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 2, environment: 'staging' } },
     })
     expect(result1.decision).toBe('deny')
@@ -489,9 +489,9 @@ describe('adversarial: policy interaction / precedence', () => {
     const result2 = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'alice' },
+      principal: { type: 'Agent::User', id: 'alice' },
       action: 'delete_record',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 10, environment: 'production' } },
     })
     expect(result2.decision).toBe('deny')
@@ -506,14 +506,14 @@ describe('adversarial: unicode and special characters', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'User', id: 'tanaka' }, attrs: { role: '管理者' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'tanaka' }, attrs: { role: '管理者' }, parents: [] },
     ]
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'tanaka' },
+      principal: { type: 'Agent::User', id: 'tanaka' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -526,14 +526,14 @@ describe('adversarial: unicode and special characters', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
     ]
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'a' },
+      principal: { type: 'Agent::User', id: 'a' },
       action: '🔍search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -546,14 +546,14 @@ describe('adversarial: unicode and special characters', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
     ]
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'a' },
+      principal: { type: 'Agent::User', id: 'a' },
       action: '',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('allow')
@@ -571,10 +571,10 @@ describe('adversarial: empty and degenerate configs', () => {
     ])
     const result = authorize({
       policies,
-      entities: [{ uid: { type: 'User', id: 'a' }, attrs: {}, parents: [] }],
-      principal: { type: 'User', id: 'a' },
+      entities: [{ uid: { type: 'Agent::User', id: 'a' }, attrs: {}, parents: [] }],
+      principal: { type: 'Agent::User', id: 'a' },
       action: 'anything',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: {} },
     })
     expect(result.decision).toBe('deny')
@@ -588,15 +588,15 @@ describe('adversarial: empty and degenerate configs', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
     ]
     // call_count >= 0 is always true, so this always denies
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'a' },
+      principal: { type: 'Agent::User', id: 'a' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { call_count: 0 } },
     })
     expect(result.decision).toBe('deny')
@@ -610,15 +610,15 @@ describe('adversarial: empty and degenerate configs', () => {
     })
     const userEntities = [
       ...entities,
-      { uid: { type: 'User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'a' }, attrs: { role: 'user' }, parents: [] },
     ]
     // hour < 12 || hour >= 12 is always true → always denied
     const result = authorize({
       policies,
       entities: userEntities,
-      principal: { type: 'User', id: 'a' },
+      principal: { type: 'Agent::User', id: 'a' },
       action: 'search',
-      resource: { type: 'Resource', id: 'agent' },
+      resource: { type: 'Agent::McpServer', id: 'agent' },
       context: { input: {}, session: { hour_utc: 12 } },
     })
     expect(result.decision).toBe('deny')
@@ -632,18 +632,18 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
       .consent(['send_email'])
       .build()
 
-    const allEntities = [...entities, { uid: { type: 'User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] }]
+    const allEntities = [...entities, { uid: { type: 'Agent::User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] }]
 
     // search: allowed (unconditional permit)
-    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'search', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'search', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
     expect(r1.decision).toBe('allow')
 
     // send_email without consent: denied
-    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
     expect(r2.decision).toBe('deny')
 
     // send_email with consent: allowed
-    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
     expect(r3.decision).toBe('allow')
   })
 
@@ -653,18 +653,18 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
       .consent(['send_email'])
       .build()
 
-    const allEntities = [...entities, { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] }]
+    const allEntities = [...entities, { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] }]
 
     // other tools: allowed (wildcard minus exclusion)
-    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'alice' }, action: 'delete_record', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'delete_record', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
     expect(r1.decision).toBe('allow')
 
     // send_email without consent: denied even for admin
-    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'alice' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
     expect(r2.decision).toBe('deny')
 
     // send_email with consent: allowed
-    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'alice' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
     expect(r3.decision).toBe('allow')
   })
 
@@ -677,20 +677,20 @@ describe('consent enforcement: consent cannot be bypassed by role permits', () =
 
     const allEntities = [
       ...entities,
-      { uid: { type: 'User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
-      { uid: { type: 'User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'alice' }, attrs: { role: 'admin' }, parents: [] },
+      { uid: { type: 'Agent::User', id: 'bob' }, attrs: { role: 'analyst' }, parents: [] },
     ]
 
     // admin: send_email allowed without consent (no consent gate for admin)
-    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'alice' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r1 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'alice' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
     expect(r1.decision).toBe('allow')
 
     // analyst: send_email denied without consent
-    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: {} } })
+    const r2 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: {} } })
     expect(r2.decision).toBe('deny')
 
     // analyst: send_email allowed with consent
-    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'User', id: 'bob' }, action: 'send_email', resource: { type: 'McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
+    const r3 = authorize({ policies, entities: allEntities, principal: { type: 'Agent::User', id: 'bob' }, action: 'send_email', resource: { type: 'Agent::McpServer', id: 'default' }, context: { input: {}, session: { user_consent: true } } })
     expect(r3.decision).toBe('allow')
   })
 })

--- a/js/cedar-agent-policy-builder/tests/builder.test.ts
+++ b/js/cedar-agent-policy-builder/tests/builder.test.ts
@@ -14,8 +14,8 @@ describe('CedarAgentPolicyBuilder', () => {
       .denyToolsInEnv('production', ['delete_record'])
       .build()
 
-    expect(result.policies).toContain('principal.role == "admin"')
-    expect(result.policies).toContain('principal.role == "analyst"')
+    expect(result.policies).toContain('Agent::Role::"admin"')
+    expect(result.policies).toContain('Agent::Role::"analyst"')
     expect(result.policies).toContain('Agent::Action::"query_database"')
     expect(result.policies).toContain('context.session has "call_count" && context.session.call_count >= 3')
     expect(result.policies).toContain('context.session has "hour_utc"')
@@ -28,14 +28,14 @@ describe('CedarAgentPolicyBuilder', () => {
       .role('viewer', ['read'])
       .build()
 
-    expect(result.policies).toContain('principal is Agent::User')
+    expect(result.policies).toContain('principal in Agent::Role::"viewer"')
   })
 
   it('generates McpServer entity even with no roles', () => {
     const result = new CedarAgentPolicyBuilder().build()
     expect(result.policies).toBe('')
     expect(result.entities).toEqual([
-      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
     ])
   })
 
@@ -48,7 +48,7 @@ describe('CedarAgentPolicyBuilder', () => {
     expect(result.policies).toContain('context.session has "user_consent" && context.session.user_consent == true')
     expect(result.policies).toContain('Agent::Action::"send_email"')
     expect(result.policies).toContain('Agent::Action::"delete_file"')
-    expect(result.policies).toContain('principal.role == "developer"')
+    expect(result.policies).toContain('Agent::Role::"developer"')
   })
 
   it('supports custom resource entity via constructor', () => {
@@ -57,7 +57,7 @@ describe('CedarAgentPolicyBuilder', () => {
     }).build()
 
     expect(result.entities).toContainEqual(
-      { uid: { type: 'AgentServer', id: 'my-agent' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::AgentServer', id: 'my-agent' }, attrs: {}, parents: [] },
     )
   })
 
@@ -144,8 +144,8 @@ describe('CedarAgentPolicyBuilder', () => {
 
       // search gets an unconditional permit
       expect(result.policies).toContain('Agent::Action::"search"')
-      // send_email does NOT get an unconditional permit — only a consent-gated one
-      expect(result.policies).not.toMatch(/action == Agent::Action::"send_email".*\n.*\) when \{ principal\.role/)
+      // send_email does NOT get an unconditional role permit — only a consent-gated one
+      expect(result.policies).not.toMatch(/principal in Agent::Role::"analyst", action == Agent::Action::"send_email", resource\);/)
       expect(result.policies).toContain('context.session has "user_consent" && context.session.user_consent == true')
     })
 

--- a/js/cedar-agent-policy-builder/tests/builder.test.ts
+++ b/js/cedar-agent-policy-builder/tests/builder.test.ts
@@ -16,7 +16,7 @@ describe('CedarAgentPolicyBuilder', () => {
 
     expect(result.policies).toContain('principal.role == "admin"')
     expect(result.policies).toContain('principal.role == "analyst"')
-    expect(result.policies).toContain('Action::"query_database"')
+    expect(result.policies).toContain('Agent::Action::"query_database"')
     expect(result.policies).toContain('context.session has "call_count" && context.session.call_count >= 3')
     expect(result.policies).toContain('context.session has "hour_utc"')
     expect(result.policies).toContain('context.session has "environment" && context.session.environment == "production"')
@@ -28,7 +28,7 @@ describe('CedarAgentPolicyBuilder', () => {
       .role('viewer', ['read'])
       .build()
 
-    expect(result.policies).toContain('principal is User')
+    expect(result.policies).toContain('principal is Agent::User')
   })
 
   it('generates McpServer entity even with no roles', () => {
@@ -46,8 +46,8 @@ describe('CedarAgentPolicyBuilder', () => {
       .build()
 
     expect(result.policies).toContain('context.session has "user_consent" && context.session.user_consent == true')
-    expect(result.policies).toContain('Action::"send_email"')
-    expect(result.policies).toContain('Action::"delete_file"')
+    expect(result.policies).toContain('Agent::Action::"send_email"')
+    expect(result.policies).toContain('Agent::Action::"delete_file"')
     expect(result.policies).toContain('principal.role == "developer"')
   })
 
@@ -143,9 +143,9 @@ describe('CedarAgentPolicyBuilder', () => {
         .build()
 
       // search gets an unconditional permit
-      expect(result.policies).toContain('Action::"search"')
+      expect(result.policies).toContain('Agent::Action::"search"')
       // send_email does NOT get an unconditional permit — only a consent-gated one
-      expect(result.policies).not.toMatch(/action == Action::"send_email".*\n.*\) when \{ principal\.role/)
+      expect(result.policies).not.toMatch(/action == Agent::Action::"send_email".*\n.*\) when \{ principal\.role/)
       expect(result.policies).toContain('context.session has "user_consent" && context.session.user_consent == true')
     })
 
@@ -156,7 +156,7 @@ describe('CedarAgentPolicyBuilder', () => {
         .build()
 
       // Wildcard permit should exclude send_email
-      expect(result.policies).toContain('!(action == Action::"send_email")')
+      expect(result.policies).toContain('!(action == Agent::Action::"send_email")')
       // Consent permit should exist
       expect(result.policies).toContain('context.session has "user_consent" && context.session.user_consent == true')
     })

--- a/js/cedar-agent-policy-builder/tests/builder.test.ts
+++ b/js/cedar-agent-policy-builder/tests/builder.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { CedarAgentPolicyBuilder } from '../src/builder.js'
 
 describe('CedarAgentPolicyBuilder', () => {
-  it('supports fluent chaining', () => {
-    const builder = new CedarAgentPolicyBuilder()
-    const result = builder
-      .principal({ key: 'user_id', type: 'User' })
+  it('supports fluent chaining with schema config in constructor', () => {
+    const result = new CedarAgentPolicyBuilder({
+      principal: { key: 'user_id', type: 'User' },
+    })
       .role('admin', ['*'])
       .role('analyst', ['search', 'query_database'])
       .restrict('query_database', { allowedValues: { database: ['analytics', 'reporting'] } })
@@ -23,7 +23,7 @@ describe('CedarAgentPolicyBuilder', () => {
     expect(result.entities).toHaveLength(3) // 2 roles + McpServer
   })
 
-  it('defaults principal type to User', () => {
+  it('defaults principal type to User when no constructor arg', () => {
     const result = new CedarAgentPolicyBuilder()
       .role('viewer', ['read'])
       .build()
@@ -51,23 +51,24 @@ describe('CedarAgentPolicyBuilder', () => {
     expect(result.policies).toContain('principal.role == "developer"')
   })
 
-  it('supports custom resource entity', () => {
-    const result = new CedarAgentPolicyBuilder()
-      .resource({ type: 'AgentServer', id: 'my-agent' })
-      .build()
+  it('supports custom resource entity via constructor', () => {
+    const result = new CedarAgentPolicyBuilder({
+      resource: { type: 'AgentServer', id: 'my-agent' },
+    }).build()
 
     expect(result.entities).toContainEqual(
       { uid: { type: 'AgentServer', id: 'my-agent' }, attrs: {}, parents: [] },
     )
   })
 
-  it('generates Cedar schema when tools are provided', () => {
-    const result = new CedarAgentPolicyBuilder()
-      .principal({ key: 'user_id', type: 'User' })
-      .role('analyst', ['search'])
-      .tools([
+  it('generates Cedar schema when tools are provided in constructor', () => {
+    const result = new CedarAgentPolicyBuilder({
+      principal: { key: 'user_id', type: 'User' },
+      tools: [
         { name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
-      ])
+      ],
+    })
+      .role('analyst', ['search'])
       .build()
 
     expect(result.schema).toBeDefined()
@@ -85,13 +86,13 @@ describe('CedarAgentPolicyBuilder', () => {
     expect(result.schema).toBeUndefined()
   })
 
-  it('uses custom namespace for schema generation', () => {
-    const result = new CedarAgentPolicyBuilder()
-      .namespace('MyService')
-      .tools([
+  it('uses custom namespace from constructor for schema generation', () => {
+    const result = new CedarAgentPolicyBuilder({
+      namespace: 'MyService',
+      tools: [
         { name: 'ping', inputSchema: { type: 'object', properties: {}, required: [] } },
-      ])
-      .build()
+      ],
+    }).build()
 
     expect(result.schema).toContain('namespace MyService')
   })

--- a/js/cedar-agent-policy-builder/tests/builder.test.ts
+++ b/js/cedar-agent-policy-builder/tests/builder.test.ts
@@ -20,7 +20,7 @@ describe('CedarAgentPolicyBuilder', () => {
     expect(result.policies).toContain('context.session has "call_count" && context.session.call_count >= 3')
     expect(result.policies).toContain('context.session has "hour_utc"')
     expect(result.policies).toContain('context.session has "environment" && context.session.environment == "production"')
-    expect(result.entities).toHaveLength(3) // 2 roles + McpServer
+    expect(result.entities).toHaveLength(3) // 2 roles + Resource
   })
 
   it('defaults principal type to User when no constructor arg', () => {
@@ -31,11 +31,11 @@ describe('CedarAgentPolicyBuilder', () => {
     expect(result.policies).toContain('principal in Agent::Role::"viewer"')
   })
 
-  it('generates McpServer entity even with no roles', () => {
+  it('generates Resource entity even with no roles', () => {
     const result = new CedarAgentPolicyBuilder().build()
     expect(result.policies).toBe('')
     expect(result.entities).toEqual([
-      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Resource', id: 'default' }, attrs: {}, parents: [] },
     ])
   })
 
@@ -75,7 +75,7 @@ describe('CedarAgentPolicyBuilder', () => {
     expect(result.schema).toContain('action "search"')
     expect(result.schema).toContain('searchInput')
     expect(result.schema).toContain('entity User')
-    expect(result.schema).toContain('entity McpServer')
+    expect(result.schema).toContain('entity Resource')
   })
 
   it('does not generate schema when no tools provided', () => {

--- a/js/cedar-agent-policy-builder/tests/builder.test.ts
+++ b/js/cedar-agent-policy-builder/tests/builder.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { CedarAgentPolicyBuilder } from '../src/builder.js'
+
+describe('CedarAgentPolicyBuilder', () => {
+  it('supports fluent chaining', () => {
+    const builder = new CedarAgentPolicyBuilder()
+    const result = builder
+      .principal({ key: 'user_id', type: 'User' })
+      .role('admin', ['*'])
+      .role('analyst', ['search', 'query_database'])
+      .restrict('query_database', { allowedValues: { database: ['analytics', 'reporting'] } })
+      .rateLimit('send_email', 3)
+      .timeWindow({ hourStart: 9, hourEnd: 17 })
+      .denyToolsInEnv('production', ['delete_record'])
+      .build()
+
+    expect(result.policies).toContain('principal.role == "admin"')
+    expect(result.policies).toContain('principal.role == "analyst"')
+    expect(result.policies).toContain('Action::"query_database"')
+    expect(result.policies).toContain('context.session has "call_count" && context.session.call_count >= 3')
+    expect(result.policies).toContain('context.session has "hour_utc"')
+    expect(result.policies).toContain('context.session has "environment" && context.session.environment == "production"')
+    expect(result.entities).toHaveLength(3) // 2 roles + McpServer
+  })
+
+  it('defaults principal type to User', () => {
+    const result = new CedarAgentPolicyBuilder()
+      .role('viewer', ['read'])
+      .build()
+
+    expect(result.policies).toContain('principal is User')
+  })
+
+  it('generates McpServer entity even with no roles', () => {
+    const result = new CedarAgentPolicyBuilder().build()
+    expect(result.policies).toBe('')
+    expect(result.entities).toEqual([
+      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+    ])
+  })
+
+  it('supports consent method', () => {
+    const result = new CedarAgentPolicyBuilder()
+      .role('developer', ['search', 'read_file'])
+      .consent(['send_email', 'delete_file'])
+      .build()
+
+    expect(result.policies).toContain('context.session has "user_consent" && context.session.user_consent == true')
+    expect(result.policies).toContain('Action::"send_email"')
+    expect(result.policies).toContain('Action::"delete_file"')
+    expect(result.policies).toContain('principal.role == "developer"')
+  })
+
+  it('supports custom resource entity', () => {
+    const result = new CedarAgentPolicyBuilder()
+      .resource({ type: 'AgentServer', id: 'my-agent' })
+      .build()
+
+    expect(result.entities).toContainEqual(
+      { uid: { type: 'AgentServer', id: 'my-agent' }, attrs: {}, parents: [] },
+    )
+  })
+
+  it('generates Cedar schema when tools are provided', () => {
+    const result = new CedarAgentPolicyBuilder()
+      .principal({ key: 'user_id', type: 'User' })
+      .role('analyst', ['search'])
+      .tools([
+        { name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
+      ])
+      .build()
+
+    expect(result.schema).toBeDefined()
+    expect(result.schema).toContain('action "search"')
+    expect(result.schema).toContain('searchInput')
+    expect(result.schema).toContain('entity User')
+    expect(result.schema).toContain('entity McpServer')
+  })
+
+  it('does not generate schema when no tools provided', () => {
+    const result = new CedarAgentPolicyBuilder()
+      .role('admin', ['*'])
+      .build()
+
+    expect(result.schema).toBeUndefined()
+  })
+
+  it('uses custom namespace for schema generation', () => {
+    const result = new CedarAgentPolicyBuilder()
+      .namespace('MyService')
+      .tools([
+        { name: 'ping', inputSchema: { type: 'object', properties: {}, required: [] } },
+      ])
+      .build()
+
+    expect(result.schema).toContain('namespace MyService')
+  })
+})

--- a/js/cedar-agent-policy-builder/tests/builder.test.ts
+++ b/js/cedar-agent-policy-builder/tests/builder.test.ts
@@ -94,7 +94,45 @@ describe('CedarAgentPolicyBuilder', () => {
       ],
     }).build()
 
-    expect(result.schema).toContain('namespace MyService')
+    // Namespace is stripped for validation compatibility, but schema content is generated
+    expect(result.schema).toBeDefined()
+    expect(result.schema).toContain('action "ping"')
+  })
+
+  describe('validate()', () => {
+    it('returns valid for well-formed policies with schema', () => {
+      const result = new CedarAgentPolicyBuilder({
+        tools: [{ name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } }],
+      })
+        .role('analyst', ['search'])
+        .build()
+
+      const validation = result.validate()
+      expect(validation.valid).toBe(true)
+      expect(validation.errors).toHaveLength(0)
+    })
+
+    it('returns valid when no schema (no tools provided)', () => {
+      const result = new CedarAgentPolicyBuilder()
+        .role('admin', ['*'])
+        .build()
+
+      const validation = result.validate()
+      expect(validation.valid).toBe(true)
+    })
+
+    it('detects unknown action names', () => {
+      const result = new CedarAgentPolicyBuilder({
+        tools: [{ name: 'search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } }],
+      })
+        .role('analyst', ['search', 'nonexistent_tool'])
+        .build()
+
+      const validation = result.validate()
+      expect(validation.valid).toBe(false)
+      expect(validation.errors.length).toBeGreaterThan(0)
+      expect(validation.errors[0].message).toContain('nonexistent_tool')
+    })
   })
 
   describe('consent + role interaction (default-deny)', () => {

--- a/js/cedar-agent-policy-builder/tests/builder.test.ts
+++ b/js/cedar-agent-policy-builder/tests/builder.test.ts
@@ -96,4 +96,40 @@ describe('CedarAgentPolicyBuilder', () => {
 
     expect(result.schema).toContain('namespace MyService')
   })
+
+  describe('consent + role interaction (default-deny)', () => {
+    it('auto-excludes consent tools from role permit', () => {
+      const result = new CedarAgentPolicyBuilder()
+        .role('analyst', ['search', 'send_email'])
+        .consent(['send_email'])
+        .build()
+
+      // search gets an unconditional permit
+      expect(result.policies).toContain('Action::"search"')
+      // send_email does NOT get an unconditional permit — only a consent-gated one
+      expect(result.policies).not.toMatch(/action == Action::"send_email".*\n.*\) when \{ principal\.role/)
+      expect(result.policies).toContain('context.session has "user_consent" && context.session.user_consent == true')
+    })
+
+    it('wildcard role excludes consent tools', () => {
+      const result = new CedarAgentPolicyBuilder()
+        .role('admin', ['*'])
+        .consent(['send_email'])
+        .build()
+
+      // Wildcard permit should exclude send_email
+      expect(result.policies).toContain('!(action == Action::"send_email")')
+      // Consent permit should exist
+      expect(result.policies).toContain('context.session has "user_consent" && context.session.user_consent == true')
+    })
+
+    it('wildcard without consent has no exclusion', () => {
+      const result = new CedarAgentPolicyBuilder()
+        .role('admin', ['*'])
+        .build()
+
+      // No exclusion clause
+      expect(result.policies).not.toContain('!(')
+    })
+  })
 })

--- a/js/cedar-agent-policy-builder/tests/entities.test.ts
+++ b/js/cedar-agent-policy-builder/tests/entities.test.ts
@@ -7,7 +7,7 @@ describe('generateEntities', () => {
   it('generates McpServer resource entity even with no roles', () => {
     const config: CedarAgentConfig = { principal: { key: 'user_id' } }
     expect(generateEntities(config)).toEqual([
-      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
     ])
   })
 
@@ -18,9 +18,9 @@ describe('generateEntities', () => {
     }
     const entities = generateEntities(config)
     expect(entities).toEqual([
-      { uid: { type: 'Role', id: 'admin' }, attrs: {}, parents: [] },
-      { uid: { type: 'Role', id: 'analyst' }, attrs: {}, parents: [] },
-      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Role', id: 'admin' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Role', id: 'analyst' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
     ])
   })
 
@@ -32,7 +32,7 @@ describe('generateEntities', () => {
     }
     const entities = generateEntities(config)
     expect(entities).toContainEqual(
-      { uid: { type: 'AgentServer', id: 'my-agent' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::AgentServer', id: 'my-agent' }, attrs: {}, parents: [] },
     )
   })
 })

--- a/js/cedar-agent-policy-builder/tests/entities.test.ts
+++ b/js/cedar-agent-policy-builder/tests/entities.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { generateEntities } from '../src/entities.js'
+import type { CedarAgentConfig } from '../src/types.js'
+import type { EntityJson } from '@cedar-policy/cedar-wasm'
+
+describe('generateEntities', () => {
+  it('generates McpServer resource entity even with no roles', () => {
+    const config: CedarAgentConfig = { principal: { key: 'user_id' } }
+    expect(generateEntities(config)).toEqual([
+      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+    ])
+  })
+
+  it('generates Role entities and McpServer resource for each defined role', () => {
+    const config: CedarAgentConfig = {
+      principal: { key: 'user_id' },
+      roles: { admin: ['*'], analyst: ['search'] },
+    }
+    const entities = generateEntities(config)
+    expect(entities).toEqual([
+      { uid: { type: 'Role', id: 'admin' }, attrs: {}, parents: [] },
+      { uid: { type: 'Role', id: 'analyst' }, attrs: {}, parents: [] },
+      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+    ])
+  })
+
+  it('uses custom resource type and id when specified', () => {
+    const config: CedarAgentConfig = {
+      principal: { key: 'user_id' },
+      roles: { viewer: ['read'] },
+      resource: { type: 'AgentServer', id: 'my-agent' },
+    }
+    const entities = generateEntities(config)
+    expect(entities).toContainEqual(
+      { uid: { type: 'AgentServer', id: 'my-agent' }, attrs: {}, parents: [] },
+    )
+  })
+})

--- a/js/cedar-agent-policy-builder/tests/entities.test.ts
+++ b/js/cedar-agent-policy-builder/tests/entities.test.ts
@@ -7,7 +7,7 @@ describe('generateEntities', () => {
   it('generates McpServer resource entity even with no roles', () => {
     const config: CedarAgentConfig = { principal: { key: 'user_id' } }
     expect(generateEntities(config)).toEqual([
-      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Resource', id: 'default' }, attrs: {}, parents: [] },
     ])
   })
 
@@ -20,7 +20,7 @@ describe('generateEntities', () => {
     expect(entities).toEqual([
       { uid: { type: 'Agent::Role', id: 'admin' }, attrs: {}, parents: [] },
       { uid: { type: 'Agent::Role', id: 'analyst' }, attrs: {}, parents: [] },
-      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Resource', id: 'default' }, attrs: {}, parents: [] },
     ])
   })
 

--- a/js/cedar-agent-policy-builder/tests/from-config.test.ts
+++ b/js/cedar-agent-policy-builder/tests/from-config.test.ts
@@ -13,13 +13,13 @@ describe('fromConfig', () => {
     })
 
     expect(policies).toContain(
-      `permit(\n  principal is Agent::User,\n  action,\n  resource\n) when { principal.role == "admin" };`
+      `permit(principal in Agent::Role::"admin", action, resource);`
     )
     expect(policies).toContain(
-      `permit(\n  principal is Agent::User,\n  action == Agent::Action::"search",\n  resource\n) when { principal.role == "analyst" };`
+      `permit(principal in Agent::Role::"analyst", action == Agent::Action::"search", resource);`
     )
     expect(policies).toContain(
-      `permit(\n  principal is Agent::User,\n  action == Agent::Action::"query_database",\n  resource\n) when { principal.role == "analyst" };`
+      `permit(principal in Agent::Role::"analyst", action == Agent::Action::"query_database", resource);`
     )
     expect(policies).toContain(
       `forbid(\n  principal,\n  action == Agent::Action::"query_database",\n  resource\n) when {\n  !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))\n};`
@@ -35,9 +35,9 @@ describe('fromConfig', () => {
     )
 
     expect(entities).toEqual([
-      { uid: { type: 'Role', id: 'admin' }, attrs: {}, parents: [] },
-      { uid: { type: 'Role', id: 'analyst' }, attrs: {}, parents: [] },
-      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Role', id: 'admin' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Role', id: 'analyst' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
     ])
   })
 })

--- a/js/cedar-agent-policy-builder/tests/from-config.test.ts
+++ b/js/cedar-agent-policy-builder/tests/from-config.test.ts
@@ -37,7 +37,7 @@ describe('fromConfig', () => {
     expect(entities).toEqual([
       { uid: { type: 'Agent::Role', id: 'admin' }, attrs: {}, parents: [] },
       { uid: { type: 'Agent::Role', id: 'analyst' }, attrs: {}, parents: [] },
-      { uid: { type: 'Agent::McpServer', id: 'default' }, attrs: {}, parents: [] },
+      { uid: { type: 'Agent::Resource', id: 'default' }, attrs: {}, parents: [] },
     ])
   })
 })

--- a/js/cedar-agent-policy-builder/tests/from-config.test.ts
+++ b/js/cedar-agent-policy-builder/tests/from-config.test.ts
@@ -13,25 +13,25 @@ describe('fromConfig', () => {
     })
 
     expect(policies).toContain(
-      `permit(\n  principal is User,\n  action,\n  resource\n) when { principal.role == "admin" };`
+      `permit(\n  principal is Agent::User,\n  action,\n  resource\n) when { principal.role == "admin" };`
     )
     expect(policies).toContain(
-      `permit(\n  principal is User,\n  action == Action::"search",\n  resource\n) when { principal.role == "analyst" };`
+      `permit(\n  principal is Agent::User,\n  action == Agent::Action::"search",\n  resource\n) when { principal.role == "analyst" };`
     )
     expect(policies).toContain(
-      `permit(\n  principal is User,\n  action == Action::"query_database",\n  resource\n) when { principal.role == "analyst" };`
+      `permit(\n  principal is Agent::User,\n  action == Agent::Action::"query_database",\n  resource\n) when { principal.role == "analyst" };`
     )
     expect(policies).toContain(
-      `forbid(\n  principal,\n  action == Action::"query_database",\n  resource\n) when {\n  !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))\n};`
+      `forbid(\n  principal,\n  action == Agent::Action::"query_database",\n  resource\n) when {\n  !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))\n};`
     )
     expect(policies).toContain(
-      `forbid(\n  principal,\n  action == Action::"send_email",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= 3 };`
+      `forbid(\n  principal,\n  action == Agent::Action::"send_email",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= 3 };`
     )
     expect(policies).toContain(
       `forbid(\n  principal,\n  action,\n  resource\n) when { context.session has "hour_utc" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };`
     )
     expect(policies).toContain(
-      `forbid(\n  principal,\n  action == Action::"delete_record",\n  resource\n) when { context.session has "environment" && context.session.environment == "production" };`
+      `forbid(\n  principal,\n  action == Agent::Action::"delete_record",\n  resource\n) when { context.session has "environment" && context.session.environment == "production" };`
     )
 
     expect(entities).toEqual([

--- a/js/cedar-agent-policy-builder/tests/from-config.test.ts
+++ b/js/cedar-agent-policy-builder/tests/from-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { fromConfig } from '../src/builder.js'
+
+describe('fromConfig', () => {
+  it('produces expected output for the full example from the brief', () => {
+    const { policies, entities } = fromConfig({
+      principal: { key: 'user_id', type: 'User' },
+      roles: { admin: ['*'], analyst: ['search', 'query_database'] },
+      restrictions: { query_database: { allowedValues: { database: ['analytics', 'reporting'] } } },
+      rateLimits: { send_email: 3 },
+      timeWindow: { hourStart: 9, hourEnd: 17 },
+      denyInEnv: { production: ['delete_record'] },
+    })
+
+    expect(policies).toContain(
+      `permit(\n  principal is User,\n  action,\n  resource\n) when { principal.role == "admin" };`
+    )
+    expect(policies).toContain(
+      `permit(\n  principal is User,\n  action == Action::"search",\n  resource\n) when { principal.role == "analyst" };`
+    )
+    expect(policies).toContain(
+      `permit(\n  principal is User,\n  action == Action::"query_database",\n  resource\n) when { principal.role == "analyst" };`
+    )
+    expect(policies).toContain(
+      `forbid(\n  principal,\n  action == Action::"query_database",\n  resource\n) when {\n  !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))\n};`
+    )
+    expect(policies).toContain(
+      `forbid(\n  principal,\n  action == Action::"send_email",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= 3 };`
+    )
+    expect(policies).toContain(
+      `forbid(\n  principal,\n  action,\n  resource\n) when { context.session has "hour_utc" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };`
+    )
+    expect(policies).toContain(
+      `forbid(\n  principal,\n  action == Action::"delete_record",\n  resource\n) when { context.session has "environment" && context.session.environment == "production" };`
+    )
+
+    expect(entities).toEqual([
+      { uid: { type: 'Role', id: 'admin' }, attrs: {}, parents: [] },
+      { uid: { type: 'Role', id: 'analyst' }, attrs: {}, parents: [] },
+      { uid: { type: 'McpServer', id: 'default' }, attrs: {}, parents: [] },
+    ])
+  })
+})

--- a/js/cedar-agent-policy-builder/tests/integration.test.ts
+++ b/js/cedar-agent-policy-builder/tests/integration.test.ts
@@ -19,7 +19,7 @@ function authorize(opts: {
   const result = isAuthorized({
     principal: opts.principal,
     action: { type: 'Agent::Action', id: opts.action },
-    resource: { type: 'Agent::McpServer', id: 'default' },
+    resource: { type: 'Agent::Resource', id: 'default' },
     context: {
       input: opts.context?.input ?? {},
       session: { hour_utc: 12, call_count: 0, ...opts.context?.session },

--- a/js/cedar-agent-policy-builder/tests/integration.test.ts
+++ b/js/cedar-agent-policy-builder/tests/integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration examples: demonstrates how the builder's .user() API generates
+ * entity hierarchy that Cedar evaluates via the `in` operator.
+ *
+ * These tests use the builder's own output (policies + entities) end-to-end,
+ * serving as executable documentation of the two principal-resolution patterns.
+ */
+import { describe, it, expect } from 'vitest'
+import { isAuthorized } from '@cedar-policy/cedar-wasm/nodejs'
+import { CedarAgentPolicyBuilder, fromConfig } from '../src/index.js'
+
+function authorize(opts: {
+  policies: string
+  entities: Array<{ uid: { type: string; id: string }; attrs: Record<string, unknown>; parents: Array<{ type: string; id: string }> }>
+  principal: { type: string; id: string }
+  action: string
+  context?: { input?: Record<string, unknown>; session?: Record<string, unknown> }
+}) {
+  const result = isAuthorized({
+    principal: opts.principal,
+    action: { type: 'Agent::Action', id: opts.action },
+    resource: { type: 'Agent::McpServer', id: 'default' },
+    context: {
+      input: opts.context?.input ?? {},
+      session: { hour_utc: 12, call_count: 0, ...opts.context?.session },
+    },
+    policies: { staticPolicies: opts.policies },
+    entities: opts.entities as any,
+  })
+  if (result.type === 'failure') return { decision: 'error' as const, errors: result.errors }
+  return { decision: result.response.decision }
+}
+
+describe('integration: entity hierarchy with .user()', () => {
+  const { policies, entities } = new CedarAgentPolicyBuilder({
+    principal: { key: 'user_id', type: 'User' },
+  })
+    .role('admin', ['*'])
+    .role('analyst', ['search', 'query_database'])
+    .role('developer', ['deploy'])
+    .user('alice', 'admin')
+    .user('bob', 'analyst')
+    .user('charlie', 'analyst', 'developer') // multi-role
+    .build()
+
+  it('user inherits permissions from their role', () => {
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'alice' }, action: 'anything' }).decision).toBe('allow')
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'bob' }, action: 'search' }).decision).toBe('allow')
+  })
+
+  it('user cannot access tools outside their role', () => {
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'bob' }, action: 'deploy' }).decision).toBe('deny')
+  })
+
+  it('multi-role user inherits from all assigned roles', () => {
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'charlie' }, action: 'search' }).decision).toBe('allow')
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'charlie' }, action: 'deploy' }).decision).toBe('allow')
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'charlie' }, action: 'anything' }).decision).toBe('deny')
+  })
+
+  it('undeclared user is denied', () => {
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'mallory' }, action: 'search' }).decision).toBe('deny')
+  })
+})
+
+describe('integration: role as principal (no users declared)', () => {
+  const { policies, entities } = new CedarAgentPolicyBuilder()
+    .role('admin', ['*'])
+    .role('viewer', ['search'])
+    .build()
+
+  it('role entity satisfies principal in Role (self-membership)', () => {
+    expect(authorize({ policies, entities, principal: { type: 'Agent::Role', id: 'admin' }, action: 'deploy' }).decision).toBe('allow')
+    expect(authorize({ policies, entities, principal: { type: 'Agent::Role', id: 'viewer' }, action: 'search' }).decision).toBe('allow')
+  })
+
+  it('role is still constrained to its tools', () => {
+    expect(authorize({ policies, entities, principal: { type: 'Agent::Role', id: 'viewer' }, action: 'deploy' }).decision).toBe('deny')
+  })
+
+  it('unknown role is denied', () => {
+    expect(authorize({ policies, entities, principal: { type: 'Agent::Role', id: 'hacker' }, action: 'search' }).decision).toBe('deny')
+  })
+})
+
+describe('integration: fromConfig with users', () => {
+  const { policies, entities } = fromConfig({
+    principal: { key: 'user_id', type: 'User' },
+    roles: { admin: ['*'], viewer: ['search'] },
+    users: { alice: ['admin'], bob: ['viewer'] },
+  })
+
+  it('generates correct entity hierarchy', () => {
+    expect(entities).toContainEqual({
+      uid: { type: 'Agent::User', id: 'alice' },
+      attrs: {},
+      parents: [{ type: 'Agent::Role', id: 'admin' }],
+    })
+    expect(entities).toContainEqual({
+      uid: { type: 'Agent::User', id: 'bob' },
+      attrs: {},
+      parents: [{ type: 'Agent::Role', id: 'viewer' }],
+    })
+  })
+
+  it('evaluates correctly through entity hierarchy', () => {
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'alice' }, action: 'deploy' }).decision).toBe('allow')
+    expect(authorize({ policies, entities, principal: { type: 'Agent::User', id: 'bob' }, action: 'deploy' }).decision).toBe('deny')
+  })
+})

--- a/js/cedar-agent-policy-builder/tests/policy-generators.test.ts
+++ b/js/cedar-agent-policy-builder/tests/policy-generators.test.ts
@@ -22,10 +22,10 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain(
-        `permit(\n  principal is User,\n  action == Action::"search",\n  resource\n) when { principal.role == "analyst" };`
+        `permit(\n  principal is Agent::User,\n  action == Agent::Action::"search",\n  resource\n) when { principal.role == "analyst" };`
       )
       expect(policies).toContain(
-        `permit(\n  principal is User,\n  action == Action::"query_database",\n  resource\n) when { principal.role == "analyst" };`
+        `permit(\n  principal is Agent::User,\n  action == Agent::Action::"query_database",\n  resource\n) when { principal.role == "analyst" };`
       )
     })
 
@@ -36,7 +36,7 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain(
-        `permit(\n  principal is User,\n  action,\n  resource\n) when { principal.role == "admin" };`
+        `permit(\n  principal is Agent::User,\n  action,\n  resource\n) when { principal.role == "admin" };`
       )
     })
 
@@ -46,7 +46,7 @@ describe('generatePolicies', () => {
         roles: { viewer: ['read'] },
       }
       const policies = generatePolicies(config)
-      expect(policies).toContain('principal is User')
+      expect(policies).toContain('principal is Agent::User')
     })
 
     it('uses custom principal type', () => {
@@ -55,7 +55,7 @@ describe('generatePolicies', () => {
         roles: { viewer: ['read'] },
       }
       const policies = generatePolicies(config)
-      expect(policies).toContain('principal is Agent')
+      expect(policies).toContain('principal is Agent::Agent')
     })
   })
 
@@ -69,7 +69,7 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain(
-        `forbid(\n  principal,\n  action == Action::"query_database",\n  resource\n) when {\n  !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))\n};`
+        `forbid(\n  principal,\n  action == Agent::Action::"query_database",\n  resource\n) when {\n  !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))\n};`
       )
     })
 
@@ -82,7 +82,7 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain(
-        `forbid(\n  principal,\n  action == Action::"delete_file",\n  resource\n) when {\n  !(context.input has "path" && (context.input.path == "/tmp"))\n};`
+        `forbid(\n  principal,\n  action == Agent::Action::"delete_file",\n  resource\n) when {\n  !(context.input has "path" && (context.input.path == "/tmp"))\n};`
       )
     })
   })
@@ -95,7 +95,7 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain(
-        `forbid(\n  principal,\n  action == Action::"send_email",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= 3 };`
+        `forbid(\n  principal,\n  action == Agent::Action::"send_email",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= 3 };`
       )
     })
   })
@@ -121,7 +121,7 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain(
-        `forbid(\n  principal,\n  action == Action::"delete_record",\n  resource\n) when { context.session has "environment" && context.session.environment == "production" };`
+        `forbid(\n  principal,\n  action == Agent::Action::"delete_record",\n  resource\n) when { context.session has "environment" && context.session.environment == "production" };`
       )
     })
 
@@ -131,8 +131,8 @@ describe('generatePolicies', () => {
         denyInEnv: { production: ['delete_record', 'drop_table'] },
       }
       const policies = generatePolicies(config)
-      expect(policies).toContain('Action::"delete_record"')
-      expect(policies).toContain('Action::"drop_table"')
+      expect(policies).toContain('Agent::Action::"delete_record"')
+      expect(policies).toContain('Agent::Action::"drop_table"')
     })
   })
 
@@ -182,7 +182,7 @@ describe('generatePolicies', () => {
         roles: { 'role"evil': ['tool"inject'] },
       }
       const policies = generatePolicies(config)
-      expect(policies).toContain('Action::"tool\\"inject"')
+      expect(policies).toContain('Agent::Action::"tool\\"inject"')
       expect(policies).toContain('principal.role == "role\\"evil"')
     })
   })

--- a/js/cedar-agent-policy-builder/tests/policy-generators.test.ts
+++ b/js/cedar-agent-policy-builder/tests/policy-generators.test.ts
@@ -22,10 +22,10 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain(
-        `permit(\n  principal is Agent::User,\n  action == Agent::Action::"search",\n  resource\n) when { principal.role == "analyst" };`
+        `permit(principal in Agent::Role::"analyst", action == Agent::Action::"search", resource);`
       )
       expect(policies).toContain(
-        `permit(\n  principal is Agent::User,\n  action == Agent::Action::"query_database",\n  resource\n) when { principal.role == "analyst" };`
+        `permit(principal in Agent::Role::"analyst", action == Agent::Action::"query_database", resource);`
       )
     })
 
@@ -36,7 +36,7 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain(
-        `permit(\n  principal is Agent::User,\n  action,\n  resource\n) when { principal.role == "admin" };`
+        `permit(principal in Agent::Role::"admin", action, resource);`
       )
     })
 
@@ -46,16 +46,16 @@ describe('generatePolicies', () => {
         roles: { viewer: ['read'] },
       }
       const policies = generatePolicies(config)
-      expect(policies).toContain('principal is Agent::User')
+      expect(policies).toContain('principal in Agent::Role::"viewer"')
     })
 
-    it('uses custom principal type', () => {
+    it('custom principal type does not affect role policies', () => {
       const config: CedarAgentConfig = {
         principal: { key: 'agent_id', type: 'Agent' },
         roles: { viewer: ['read'] },
       }
       const policies = generatePolicies(config)
-      expect(policies).toContain('principal is Agent::Agent')
+      expect(policies).toContain('principal in Agent::Role::"viewer"')
     })
   })
 
@@ -183,7 +183,7 @@ describe('generatePolicies', () => {
       }
       const policies = generatePolicies(config)
       expect(policies).toContain('Agent::Action::"tool\\"inject"')
-      expect(policies).toContain('principal.role == "role\\"evil"')
+      expect(policies).toContain('Agent::Role::"role\\"evil"')
     })
   })
 

--- a/js/cedar-agent-policy-builder/tests/policy-generators.test.ts
+++ b/js/cedar-agent-policy-builder/tests/policy-generators.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest'
+import { generatePolicies, escapeCedarString } from '../src/policy-generators.js'
+import type { CedarAgentConfig } from '../src/types.js'
+
+describe('escapeCedarString', () => {
+  it('escapes backslashes and quotes', () => {
+    expect(escapeCedarString('hello "world"')).toBe('hello \\"world\\"')
+    expect(escapeCedarString('back\\slash')).toBe('back\\\\slash')
+  })
+
+  it('leaves plain strings unchanged', () => {
+    expect(escapeCedarString('admin')).toBe('admin')
+  })
+})
+
+describe('generatePolicies', () => {
+  describe('role policies', () => {
+    it('generates permit for specific tools', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id', type: 'User' },
+        roles: { analyst: ['search', 'query_database'] },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain(
+        `permit(\n  principal is User,\n  action == Action::"search",\n  resource\n) when { principal.role == "analyst" };`
+      )
+      expect(policies).toContain(
+        `permit(\n  principal is User,\n  action == Action::"query_database",\n  resource\n) when { principal.role == "analyst" };`
+      )
+    })
+
+    it('generates wildcard permit for admin role', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id', type: 'User' },
+        roles: { admin: ['*'] },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain(
+        `permit(\n  principal is User,\n  action,\n  resource\n) when { principal.role == "admin" };`
+      )
+    })
+
+    it('defaults principal type to User', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        roles: { viewer: ['read'] },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain('principal is User')
+    })
+
+    it('uses custom principal type', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'agent_id', type: 'Agent' },
+        roles: { viewer: ['read'] },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain('principal is Agent')
+    })
+  })
+
+  describe('restriction policies', () => {
+    it('generates forbid with allowed values check', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        restrictions: {
+          query_database: { allowedValues: { database: ['analytics', 'reporting'] } },
+        },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain(
+        `forbid(\n  principal,\n  action == Action::"query_database",\n  resource\n) when {\n  !(context.input has "database" && (context.input.database == "analytics" || context.input.database == "reporting"))\n};`
+      )
+    })
+
+    it('handles single allowed value', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        restrictions: {
+          delete_file: { allowedValues: { path: ['/tmp'] } },
+        },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain(
+        `forbid(\n  principal,\n  action == Action::"delete_file",\n  resource\n) when {\n  !(context.input has "path" && (context.input.path == "/tmp"))\n};`
+      )
+    })
+  })
+
+  describe('rate limit policies', () => {
+    it('generates forbid with call_count check', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        rateLimits: { send_email: 3 },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain(
+        `forbid(\n  principal,\n  action == Action::"send_email",\n  resource\n) when { context.session has "call_count" && context.session.call_count >= 3 };`
+      )
+    })
+  })
+
+  describe('time window policies', () => {
+    it('generates forbid with hour checks', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        timeWindow: { hourStart: 9, hourEnd: 17 },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain(
+        `forbid(\n  principal,\n  action,\n  resource\n) when { context.session has "hour_utc" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };`
+      )
+    })
+  })
+
+  describe('environment denial policies', () => {
+    it('generates forbid with environment check', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        denyInEnv: { production: ['delete_record'] },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain(
+        `forbid(\n  principal,\n  action == Action::"delete_record",\n  resource\n) when { context.session has "environment" && context.session.environment == "production" };`
+      )
+    })
+
+    it('generates one policy per tool', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        denyInEnv: { production: ['delete_record', 'drop_table'] },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain('Action::"delete_record"')
+      expect(policies).toContain('Action::"drop_table"')
+    })
+  })
+
+  describe('restriction policies - edge cases', () => {
+    it('generates one forbid per field when multiple fields constrained', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        restrictions: {
+          query_database: {
+            allowedValues: {
+              database: ['analytics', 'reporting'],
+              schema: ['public'],
+            },
+          },
+        },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain('context.input.database == "analytics" || context.input.database == "reporting"')
+      expect(policies).toContain('context.input.schema == "public"')
+    })
+
+    it('handles numeric allowed values', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        restrictions: {
+          set_limit: { allowedValues: { limit: [10, 50, 100] } },
+        },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain('context.input.limit == 10 || context.input.limit == 50 || context.input.limit == 100')
+    })
+  })
+
+  describe('role policies - edge cases', () => {
+    it('generates nothing for a role with empty tools array', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id' },
+        roles: { empty: [] },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toBe('')
+    })
+
+    it('escapes special characters in role and tool names', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id', type: 'User' },
+        roles: { 'role"evil': ['tool"inject'] },
+      }
+      const policies = generatePolicies(config)
+      expect(policies).toContain('Action::"tool\\"inject"')
+      expect(policies).toContain('principal.role == "role\\"evil"')
+    })
+  })
+
+  describe('combined policies', () => {
+    it('joins multiple policies with double newline', () => {
+      const config: CedarAgentConfig = {
+        principal: { key: 'user_id', type: 'User' },
+        roles: { admin: ['*'] },
+        rateLimits: { send_email: 3 },
+      }
+      const policies = generatePolicies(config)
+      const parts = policies.split('\n\n')
+      expect(parts.length).toBe(2)
+    })
+  })
+
+  it('returns empty string when no policies configured', () => {
+    const config: CedarAgentConfig = { principal: { key: 'user_id' } }
+    expect(generatePolicies(config)).toBe('')
+  })
+})

--- a/js/cedar-agent-policy-builder/tsconfig.json
+++ b/js/cedar-agent-policy-builder/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Description of changes

Adds `js/cedar-agent-policy-builder/`: a TypeScript library that generates Cedar policies, entities, and schemas for agent authorization from declarative configuration. Integrates with [`@cedar-policy/mcp-schema-generator-wasm`](https://www.npmjs.com/package/@cedar-policy/mcp-schema-generator-wasm) for schema generation and [`@cedar-policy/cedar-wasm`](https://www.npmjs.com/package/@cedar-policy/cedar-wasm) for policy validation.

### Usage

**Builder API:**

```typescript
import { CedarAgentPolicyBuilder } from 'cedar-agent-policy-builder'
import { allTools } from './tools' // your tool definitions

const { policies, entities, schema } = new CedarAgentPolicyBuilder({
  // Schema configuration — defines types and structure
  principal: { key: 'user_id', type: 'User' },
  tools: allTools.map(t => t.spec), // MCP tool definitions for schema generation
})
  // Policy configuration — defines who can do what
  .role('admin', ['*'])
  .role('analyst', ['search', 'query_database'])
  .restrict('query_database', { allowedValues: { database: ['analytics', 'reporting'] } })
  .rateLimit('send_email', 3)
  .timeWindow({ hourStart: 9, hourEnd: 17 })
  .denyToolsInEnv('production', ['delete_record'])
  .consent(['send_email', 'delete_file'])
  .build()

// policies: Generated Cedar permit/forbid rules as a string
// entities: Cedar entities array (Role entities + McpServer resource entity)
// schema: Cedar schema generated from tool inputSchemas (for build-time policy validation)
```

**From config (JSON/object):**

```typescript
import { fromConfig } from 'cedar-agent-policy-builder'

const { policies, entities } = fromConfig({
  principal: { key: 'user_id', type: 'User' },
  roles: { admin: ['*'], analyst: ['search', 'query_database'] },
  restrictions: { query_database: { allowedValues: { database: ['analytics', 'reporting'] } } },
  rateLimits: { send_email: 3 },
  consent: { send_email: ['*'], delete_file: ['*'] },
})
```

**`tools` accepts MCP tool definitions (framework-agnostic):**

```typescript
// From any MCP server's list_tools response:
new CedarAgentPolicyBuilder({ tools: mcpServer.listTools().tools })

// From Strands tool specs:
new CedarAgentPolicyBuilder({ tools: allTools.map(t => t.spec) })

// From OpenAI Agents:
new CedarAgentPolicyBuilder({ tools: myTools.map(t => ({ name: t.name, inputSchema: t.parameters })) })
```

**Full Strands integration (with [`CedarAuthorization` intervention handler](https://github.com/strands-agents/harness-sdk/pull/2365)):**

```typescript
import { Agent, tool } from '@strands-agents/sdk'
import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
import { CedarAgentPolicyBuilder } from 'cedar-agent-policy-builder'
import { z } from 'zod'

const searchTool = tool({
  name: 'search',
  description: 'Search for information',
  inputSchema: z.object({ query: z.string() }),
  callback: (input) => `Results for: ${input.query}`,
})

const queryDatabase = tool({
  name: 'query_database',
  description: 'Query a database',
  inputSchema: z.object({ database: z.string(), query: z.string() }),
  callback: (input) => `[${input.database}] ${input.query} → 42 rows`,
})

const allTools = [searchTool, queryDatabase]

// Generate policies from declarative config, schema from tool definitions
const { policies, schema } = new CedarAgentPolicyBuilder({
  principal: { key: 'user_id', type: 'User' },
  tools: allTools.map(t => t.spec),
})
  .role('admin', ['*'])
  .role('analyst', ['search', 'query_database'])
  .restrict('query_database', { allowedValues: { database: ['analytics', 'reporting'] } })
  .build()

// CedarAuthorization evaluates the generated policies at runtime
const cedar = new CedarAuthorization({
  policies,
  schema,
  contextEnricher: ({ invocationState }) => ({
    role: String(invocationState.role ?? 'none'),
  }),
})

const agent = new Agent({
  tools: allTools,
  interventions: [cedar],
})

await agent.invoke('Search for reports', { invocationState: { user_id: 'bob', role: 'analyst' } })
// → allowed

await agent.invoke('Query the secrets database', { invocationState: { user_id: 'bob', role: 'analyst' } })
// → denied (analyst restricted to analytics/reporting)
```

**How it integrates with the MCP schema generator:**

```
constructor { tools } ─────────┐
                               ├──► @cedar-policy/mcp-schema-generator-wasm ──► Cedar schema
constructor { principal } ─────┘                                                     │
                                                                                     ▼
.role()/.restrict()/.consent() ──► Policy generator ──► Cedar policies ──► validate(policies, schema)
                                                                            catches typos/type errors
                                                                            at build time
```

## Issue #, if available

N/A — supporting the Cedar authorization and Intervention Primitive design proposals:
- [strands-agents/docs#0006 — Cedar Authorization](https://github.com/strands-agents/docs/blob/main/designs/0006-cedar-authorization.md)
- [strands-agents/docs#0007 — Intervention Primitive](https://github.com/strands-agents/docs/blob/main/designs/0007-intervention-primitive.md)

## Checklist for requesting a review

The change in this PR is:

- [x] A backwards-compatible change requiring a minor version bump to any crates in this repository (e.g., addition of a new API).
  * `cedar-agent-policy-builder` (new package)

I confirm that this PR:

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).