### PR TITLE
feat: add Python bindings for cedar-policy-mcp-schema-generator 

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -748,15 +748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,15 +920,6 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "miette"
@@ -1201,37 +1183,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1239,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1251,13 +1228,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1774,12 +1750,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -311,6 +311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cedar-policy-mcp-schema-generator-python"
+version = "0.6.0"
+dependencies = [
+ "cedar-policy-mcp-schema-generator",
+ "mcp-tools-sdk",
+ "pyo3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cedar-policy-mcp-schema-generator-wasm"
 version = "0.6.0"
 dependencies = [
@@ -737,6 +748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +929,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miette"
@@ -1097,6 +1126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,6 +1197,69 @@ checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1497,6 +1595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1774,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	"cedar-policy-mcp-schema-generator",
+	"cedar-policy-mcp-schema-generator-python",
 	"cedar-policy-mcp-schema-generator-wasm",
 	"mcp-tools-sdk",
 ]

--- a/rust/cedar-policy-mcp-schema-generator-python/.gitignore
+++ b/rust/cedar-policy-mcp-schema-generator-python/.gitignore
@@ -1,0 +1,10 @@
+.venv/
+target/
+__pycache__/
+.pytest_cache/
+*.egg-info/
+dist/
+*.so
+*.dylib
+*.pyd
+Cargo.lock

--- a/rust/cedar-policy-mcp-schema-generator-python/Cargo.toml
+++ b/rust/cedar-policy-mcp-schema-generator-python/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator" }
 mcp-tools-sdk = { path = "../mcp-tools-sdk" }
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/rust/cedar-policy-mcp-schema-generator-python/Cargo.toml
+++ b/rust/cedar-policy-mcp-schema-generator-python/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cedar-policy-mcp-schema-generator-python"
+description = "Python bindings for cedar-policy-mcp-schema-generator, exposing SchemaGenerator via PyO3."
+version = "0.6.0"
+
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+categories.workspace = true
+keywords.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lib]
+name = "cedar_mcp_schema_generator"
+crate-type = ["cdylib"]
+
+[dependencies]
+cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator" }
+mcp-tools-sdk = { path = "../mcp-tools-sdk" }
+pyo3 = { version = "0.24", features = ["extension-module"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/rust/cedar-policy-mcp-schema-generator-python/README.md
+++ b/rust/cedar-policy-mcp-schema-generator-python/README.md
@@ -1,0 +1,123 @@
+# Cedar MCP Schema Generator - Python Bindings
+
+Python bindings for the [Cedar MCP Schema Generator](../cedar-policy-mcp-schema-generator/),
+enabling Python environments to generate Cedar authorization schemas from MCP tool descriptions.
+
+## Installation
+
+Requires a Rust toolchain (1.90+) and [maturin](https://www.maturin.rs/):
+
+```bash
+pip install maturin
+cd python/cedar-policy-mcp-schema-generator
+maturin develop
+```
+
+## Usage
+
+### Generate a Cedar schema from MCP tools
+
+```python
+from cedar_mcp_schema_generator import generate_schema
+
+schema_stub = """
+namespace MyServer {
+    @mcp_principal
+    entity User;
+    @mcp_resource
+    entity McpServer;
+    action "call_tool" appliesTo {
+        principal: [User],
+        resource: [McpServer]
+    };
+}
+"""
+
+tools = [
+    {
+        "name": "read_file",
+        "description": "Read a file from disk",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    }
+]
+
+result = generate_schema(schema_stub, tools)
+if result["isOk"]:
+    print(result["schema"])       # Human-readable .cedarschema format
+    print(result["schemaJson"])   # JSON format for Cedar evaluation
+else:
+    print(f"Error: {result['error']}")
+```
+
+### Generate a Cedar authorization request
+
+```python
+from cedar_mcp_schema_generator import generate_request
+
+result = generate_request(
+    schema_stub,
+    tools,
+    {"params": {"tool": "read_file", "args": {"path": "/etc/hosts"}}},
+    principal_type="User",
+    principal_id="alice",
+    resource_type="McpServer",
+    resource_id="my-server",
+)
+
+if result["isOk"]:
+    print(result["principal"])    # e.g., MyServer::User::"alice"
+    print(result["action"])       # e.g., MyServer::Action::"read_file"
+    print(result["resource"])     # e.g., MyServer::McpServer::"my-server"
+    print(result["entitiesJson"]) # JSON array of entities
+```
+
+### Configuration
+
+Both functions accept an optional `config` dict:
+
+```python
+result = generate_schema(
+    schema_stub,
+    tools,
+    config={
+        "includeOutputs": False,         # Include tool outputs in schema context
+        "objectsAsRecords": False,       # Encode objects as Cedar records
+        "eraseAnnotations": True,        # Remove mcp annotations from output
+        "flattenNamespaces": False,      # Flatten nested namespaces
+        "numbersAsDecimal": False,       # Encode numbers as Cedar decimals
+        "deduplicateEntityTypes": False, # Deduplicate equivalent enum types
+    },
+)
+```
+
+### Exception-raising variants
+
+For convenience, `_or_raise` variants raise on failure instead of returning error dicts:
+
+```python
+from cedar_mcp_schema_generator import generate_schema_or_raise, SchemaGeneratorError
+
+try:
+    result = generate_schema_or_raise(schema_stub, tools)
+    print(result["schema"])
+except SchemaGeneratorError as e:
+    print(f"Failed: {e}")
+```
+
+## API Reference
+
+### `generate_schema(schema_stub, tools, *, config=None) -> dict`
+
+Returns `{"isOk": bool, "schema": str|None, "schemaJson": str|None, "error": str|None}`.
+
+### `generate_request(schema_stub, tools, input, *, principal_type, principal_id, resource_type, resource_id, config=None) -> dict`
+
+Returns `{"isOk": bool, "principal": str|None, "action": str|None, "resource": str|None, "entitiesJson": str|None, "error": str|None}`.
+
+## License
+
+Apache-2.0

--- a/rust/cedar-policy-mcp-schema-generator-python/README.md
+++ b/rust/cedar-policy-mcp-schema-generator-python/README.md
@@ -5,11 +5,11 @@ enabling Python environments to generate Cedar authorization schemas from MCP to
 
 ## Installation
 
-Requires a Rust toolchain (1.90+) and [maturin](https://www.maturin.rs/):
+Requires Python 3.9+, a Rust toolchain (1.90+), and [maturin](https://www.maturin.rs/):
 
 ```bash
 pip install maturin
-cd python/cedar-policy-mcp-schema-generator
+cd rust/cedar-policy-mcp-schema-generator-python
 maturin develop
 ```
 

--- a/rust/cedar-policy-mcp-schema-generator-python/cedar_mcp_schema_generator/__init__.py
+++ b/rust/cedar-policy-mcp-schema-generator-python/cedar_mcp_schema_generator/__init__.py
@@ -1,0 +1,173 @@
+# Copyright Cedar Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cedar MCP Schema Generator - Python bindings.
+
+Generate Cedar authorization schemas and requests from MCP tool descriptions.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from cedar_mcp_schema_generator._native import (
+    generate_request as _generate_request,
+    generate_schema as _generate_schema,
+)
+
+
+class SchemaGeneratorError(Exception):
+    """Raised when schema generation fails."""
+
+
+class RequestGeneratorError(Exception):
+    """Raised when request generation fails."""
+
+
+def generate_schema(
+    schema_stub: str,
+    tools: str | list[dict[str, Any]],
+    *,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Generate a Cedar schema from a stub and MCP tool descriptions.
+
+    Args:
+        schema_stub: A Cedar schema stub string with @mcp_principal and
+            @mcp_resource annotated entity types.
+        tools: MCP tool descriptions as a JSON string or list of dicts
+            (the `tools` array from an MCP tools/list response).
+        config: Optional configuration dict with keys:
+            - includeOutputs (bool): Include tool outputs in schema context.
+            - objectsAsRecords (bool): Encode objects as Cedar records.
+            - eraseAnnotations (bool): Remove mcp annotations from output.
+            - flattenNamespaces (bool): Flatten nested namespaces.
+            - numbersAsDecimal (bool): Encode numbers as Cedar decimals.
+            - deduplicateEntityTypes (bool): Deduplicate equivalent enum types.
+
+    Returns:
+        A dict with keys:
+            - isOk (bool): Whether generation succeeded.
+            - schema (str | None): Generated schema in .cedarschema format.
+            - schemaJson (str | None): Generated schema as JSON.
+            - error (str | None): Error message if generation failed.
+
+    Raises:
+        SchemaGeneratorError: If generation fails and you prefer exceptions
+            over checking isOk. Use generate_schema_or_raise() for this.
+    """
+    tools_json = json.dumps(tools) if isinstance(tools, list) else tools
+    config_json = json.dumps(config) if config else None
+    return json.loads(_generate_schema(schema_stub, tools_json, config_json))
+
+
+def generate_schema_or_raise(
+    schema_stub: str,
+    tools: str | list[dict[str, Any]],
+    *,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Like generate_schema but raises SchemaGeneratorError on failure."""
+    result = generate_schema(schema_stub, tools, config=config)
+    if not result["isOk"]:
+        raise SchemaGeneratorError(result.get("error", "Unknown error"))
+    return result
+
+
+def generate_request(
+    schema_stub: str,
+    tools: str | list[dict[str, Any]],
+    input: str | dict[str, Any],
+    *,
+    principal_type: str,
+    principal_id: str,
+    resource_type: str,
+    resource_id: str,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Generate a Cedar authorization request from an MCP tool call.
+
+    Args:
+        schema_stub: A Cedar schema stub string.
+        tools: MCP tool descriptions as a JSON string or list of dicts.
+        input: MCP tool call input as a JSON string or dict. Format:
+            {"params": {"tool": "tool_name", "args": {"key": "value"}}}.
+        principal_type: The Cedar entity type for the principal (e.g., "User").
+        principal_id: The principal identifier (e.g., "alice").
+        resource_type: The Cedar entity type for the resource (e.g., "McpServer").
+        resource_id: The resource identifier (e.g., "my-server").
+        config: Optional configuration dict (same keys as generate_schema).
+
+    Returns:
+        A dict with keys:
+            - isOk (bool): Whether generation succeeded.
+            - principal (str | None): Cedar EntityUID string.
+            - action (str | None): Cedar action EntityUID string.
+            - resource (str | None): Cedar resource EntityUID string.
+            - entitiesJson (str | None): Entities as a JSON array string.
+            - error (str | None): Error message if generation failed.
+    """
+    tools_json = json.dumps(tools) if isinstance(tools, list) else tools
+    input_json = json.dumps(input) if isinstance(input, dict) else input
+    config_json = json.dumps(config) if config else None
+    return json.loads(
+        _generate_request(
+            schema_stub,
+            tools_json,
+            input_json,
+            principal_type,
+            principal_id,
+            resource_type,
+            resource_id,
+            config_json,
+        )
+    )
+
+
+def generate_request_or_raise(
+    schema_stub: str,
+    tools: str | list[dict[str, Any]],
+    input: str | dict[str, Any],
+    *,
+    principal_type: str,
+    principal_id: str,
+    resource_type: str,
+    resource_id: str,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Like generate_request but raises RequestGeneratorError on failure."""
+    result = generate_request(
+        schema_stub,
+        tools,
+        input,
+        principal_type=principal_type,
+        principal_id=principal_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        config=config,
+    )
+    if not result["isOk"]:
+        raise RequestGeneratorError(result.get("error", "Unknown error"))
+    return result
+
+
+__all__ = [
+    "generate_schema",
+    "generate_schema_or_raise",
+    "generate_request",
+    "generate_request_or_raise",
+    "SchemaGeneratorError",
+    "RequestGeneratorError",
+]

--- a/rust/cedar-policy-mcp-schema-generator-python/cedar_mcp_schema_generator/__init__.py
+++ b/rust/cedar-policy-mcp-schema-generator-python/cedar_mcp_schema_generator/__init__.py
@@ -64,9 +64,9 @@ def generate_schema(
             - schemaJson (str | None): Generated schema as JSON.
             - error (str | None): Error message if generation failed.
 
-    Raises:
-        SchemaGeneratorError: If generation fails and you prefer exceptions
-            over checking isOk. Use generate_schema_or_raise() for this.
+    Note:
+        This function returns an error dict on failure (check the isOk field).
+        Use generate_schema_or_raise() if you prefer exceptions.
     """
     tools_json = json.dumps(tools) if isinstance(tools, list) else tools
     config_json = json.dumps(config) if config else None

--- a/rust/cedar-policy-mcp-schema-generator-python/pyproject.toml
+++ b/rust/cedar-policy-mcp-schema-generator-python/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "cedar-mcp-schema-generator"
+version = "0.6.0"
+description = "Python bindings for the Cedar MCP Schema Generator"
+requires-python = ">=3.9"
+license = "Apache-2.0"
+keywords = ["cedar", "authorization", "mcp", "schema", "agents"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Topic :: Security",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+module-name = "cedar_mcp_schema_generator._native"

--- a/rust/cedar-policy-mcp-schema-generator-python/src/lib.rs
+++ b/rust/cedar-policy-mcp-schema-generator-python/src/lib.rs
@@ -141,6 +141,10 @@ fn generate_schema(schema_stub: &str, tools_json: &str, config_json: Option<&str
 /// `error`, and `isOk` fields.
 #[pyfunction]
 #[pyo3(signature = (schema_stub, tools_json, input_json, principal_type, principal_id, resource_type, resource_id, config_json=None))]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "wasm-bindgen/pyo3 requires flat parameter lists; cannot use struct across FFI boundary"
+)]
 fn generate_request(
     schema_stub: &str,
     tools_json: &str,

--- a/rust/cedar-policy-mcp-schema-generator-python/src/lib.rs
+++ b/rust/cedar-policy-mcp-schema-generator-python/src/lib.rs
@@ -1,0 +1,319 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Python bindings for the Cedar MCP Schema Generator.
+//!
+//! Exposes [`SchemaGenerator`] to Python via PyO3, enabling Python environments
+//! to generate Cedar schemas from MCP tool descriptions with the exact same
+//! behavior as the Rust implementation.
+//!
+//! This crate is a thin wrapper: all schema generation logic is delegated to
+//! [`cedar_policy_mcp_schema_generator`].
+
+use cedar_policy_mcp_schema_generator::{SchemaGenerator, SchemaGeneratorConfig};
+use mcp_tools_sdk::data::Input;
+use mcp_tools_sdk::description::ServerDescription;
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PyConfig {
+    #[serde(default)]
+    include_outputs: bool,
+    #[serde(default)]
+    objects_as_records: bool,
+    #[serde(default = "default_true")]
+    erase_annotations: bool,
+    #[serde(default)]
+    flatten_namespaces: bool,
+    #[serde(default)]
+    numbers_as_decimal: bool,
+    #[serde(default)]
+    deduplicate_entity_types: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for PyConfig {
+    fn default() -> Self {
+        Self {
+            include_outputs: false,
+            objects_as_records: false,
+            erase_annotations: true,
+            flatten_namespaces: false,
+            numbers_as_decimal: false,
+            deduplicate_entity_types: false,
+        }
+    }
+}
+
+impl From<PyConfig> for SchemaGeneratorConfig {
+    fn from(c: PyConfig) -> Self {
+        SchemaGeneratorConfig::default()
+            .include_outputs(c.include_outputs)
+            .objects_as_records(c.objects_as_records)
+            .erase_annotations(c.erase_annotations)
+            .flatten_namespaces(c.flatten_namespaces)
+            .encode_numbers_as_decimal(c.numbers_as_decimal)
+            .deduplicate_entity_types(c.deduplicate_entity_types)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SchemaResult {
+    schema: Option<String>,
+    schema_json: Option<String>,
+    error: Option<String>,
+    is_ok: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RequestResult {
+    principal: Option<String>,
+    action: Option<String>,
+    resource: Option<String>,
+    entities_json: Option<String>,
+    error: Option<String>,
+    is_ok: bool,
+}
+
+/// Generate a Cedar schema from a schema stub and MCP tool descriptions.
+///
+/// # Arguments
+///
+/// * `schema_stub` - A Cedar schema stub as a `.cedarschema` string. Must
+///   contain entity types annotated with `@mcp_principal` and `@mcp_resource`.
+/// * `tools_json` - MCP tool descriptions as a JSON string. This should be
+///   the `tools` array from an MCP `tools/list` response.
+/// * `config_json` - Optional configuration as a JSON string. If `None` or
+///   empty, defaults are used.
+///
+/// # Returns
+///
+/// A JSON string with `schema`, `schemaJson`, `error`, and `isOk` fields.
+#[pyfunction]
+#[pyo3(signature = (schema_stub, tools_json, config_json=None))]
+fn generate_schema(schema_stub: &str, tools_json: &str, config_json: Option<&str>) -> String {
+    let result = generate_schema_inner(schema_stub, tools_json, config_json);
+    serde_json::to_string(&result).unwrap_or_else(|e| {
+        format!(
+            r#"{{"isOk":false,"error":"Serialization error: {}","schema":null,"schemaJson":null}}"#,
+            e
+        )
+    })
+}
+
+/// Generate a Cedar authorization request from an MCP tool call.
+///
+/// # Arguments
+///
+/// * `schema_stub` - A Cedar schema stub as a `.cedarschema` string.
+/// * `tools_json` - MCP tool descriptions as a JSON string.
+/// * `input_json` - MCP tool call input as a JSON string. Format:
+///   `{"params": {"tool": "tool_name", "args": {"key": "value"}}}`.
+/// * `principal_type` - The Cedar entity type for the principal (e.g., `"User"`).
+/// * `principal_id` - The principal identifier (e.g., `"alice"`).
+/// * `resource_type` - The Cedar entity type for the resource (e.g., `"McpServer"`).
+/// * `resource_id` - The resource identifier (e.g., `"my-server"`).
+/// * `config_json` - Optional configuration as a JSON string.
+///
+/// # Returns
+///
+/// A JSON string with `principal`, `action`, `resource`, `entitiesJson`,
+/// `error`, and `isOk` fields.
+#[pyfunction]
+#[pyo3(signature = (schema_stub, tools_json, input_json, principal_type, principal_id, resource_type, resource_id, config_json=None))]
+fn generate_request(
+    schema_stub: &str,
+    tools_json: &str,
+    input_json: &str,
+    principal_type: &str,
+    principal_id: &str,
+    resource_type: &str,
+    resource_id: &str,
+    config_json: Option<&str>,
+) -> String {
+    let result = generate_request_inner(
+        schema_stub,
+        tools_json,
+        input_json,
+        principal_type,
+        principal_id,
+        resource_type,
+        resource_id,
+        config_json,
+    );
+    serde_json::to_string(&result).unwrap_or_else(|e| {
+        format!(
+            r#"{{"isOk":false,"error":"Serialization error: {}","principal":null,"action":null,"resource":null,"entitiesJson":null}}"#,
+            e
+        )
+    })
+}
+
+fn generate_schema_inner(
+    schema_stub: &str,
+    tools_json: &str,
+    config_json: Option<&str>,
+) -> SchemaResult {
+    let config: SchemaGeneratorConfig = match config_json {
+        Some(json) if !json.is_empty() => {
+            let Ok(c) = serde_json::from_str::<PyConfig>(json) else {
+                return schema_err(format!(
+                    "Invalid config: {}",
+                    serde_json::from_str::<serde_json::Value>(json)
+                        .err()
+                        .map_or_else(|| "unrecognized fields".to_string(), |e| e.to_string())
+                ));
+            };
+            c.into()
+        }
+        _ => SchemaGeneratorConfig::default(),
+    };
+
+    let Ok(mut generator) = SchemaGenerator::from_cedarschema_str_with_config(schema_stub, config)
+    else {
+        return schema_err("Schema error: failed to parse schema stub".to_string());
+    };
+
+    let Ok(server_desc) = ServerDescription::from_json_str(tools_json) else {
+        return schema_err("Invalid tool descriptions: failed to parse JSON".to_string());
+    };
+
+    if let Err(e) = generator.add_actions_from_server_description(&server_desc) {
+        return schema_err(format!("Error adding tools: {e}"));
+    }
+
+    let schema_text = generator.get_schema_as_str();
+
+    let Ok(json) = serde_json::to_string_pretty(generator.get_schema()) else {
+        return SchemaResult {
+            schema: Some(schema_text),
+            schema_json: None,
+            error: Some("JSON serialization warning: failed to serialize schema".to_string()),
+            is_ok: true,
+        };
+    };
+
+    SchemaResult {
+        schema: Some(schema_text),
+        schema_json: Some(json),
+        error: None,
+        is_ok: true,
+    }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Mirrors the flat parameter list from the WASM crate"
+)]
+fn generate_request_inner(
+    schema_stub: &str,
+    tools_json: &str,
+    input_json: &str,
+    principal_type: &str,
+    principal_id: &str,
+    resource_type: &str,
+    resource_id: &str,
+    config_json: Option<&str>,
+) -> RequestResult {
+    let config: SchemaGeneratorConfig = match config_json {
+        Some(json) if !json.is_empty() => {
+            let Ok(c) = serde_json::from_str::<PyConfig>(json) else {
+                return request_err(format!(
+                    "Invalid config: {}",
+                    serde_json::from_str::<serde_json::Value>(json)
+                        .err()
+                        .map_or_else(|| "unrecognized fields".to_string(), |e| e.to_string())
+                ));
+            };
+            c.into()
+        }
+        _ => SchemaGeneratorConfig::default(),
+    };
+
+    let Ok(mut generator) = SchemaGenerator::from_cedarschema_str_with_config(schema_stub, config)
+    else {
+        return request_err("Schema error: failed to parse schema stub".to_string());
+    };
+
+    let Ok(server_desc) = ServerDescription::from_json_str(tools_json) else {
+        return request_err("Invalid tool descriptions: failed to parse JSON".to_string());
+    };
+
+    if let Err(e) = generator.add_actions_from_server_description(&server_desc) {
+        return request_err(format!("Error adding tools: {e}"));
+    }
+
+    let Ok(req_gen) = generator.new_request_generator() else {
+        return request_err("Failed to create request generator".to_string());
+    };
+
+    let Ok(input) = Input::from_json_str(input_json) else {
+        return request_err("Invalid tool input: failed to parse JSON".to_string());
+    };
+
+    match req_gen.generate_request_components_from_strings(
+        &input,
+        principal_type,
+        principal_id,
+        resource_type,
+        resource_id,
+    ) {
+        Ok(components) => RequestResult {
+            principal: Some(components.principal),
+            action: Some(components.action),
+            resource: Some(components.resource),
+            entities_json: Some(components.entities_json),
+            error: None,
+            is_ok: true,
+        },
+        Err(e) => request_err(format!("Request generation error: {e}")),
+    }
+}
+
+fn schema_err(error: String) -> SchemaResult {
+    SchemaResult {
+        schema: None,
+        schema_json: None,
+        error: Some(error),
+        is_ok: false,
+    }
+}
+
+fn request_err(error: String) -> RequestResult {
+    RequestResult {
+        principal: None,
+        action: None,
+        resource: None,
+        entities_json: None,
+        error: Some(error),
+        is_ok: false,
+    }
+}
+
+#[pymodule]
+#[pyo3(name = "_native")]
+fn cedar_mcp_schema_generator(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(generate_schema, m)?)?;
+    m.add_function(wrap_pyfunction!(generate_request, m)?)?;
+    Ok(())
+}

--- a/rust/cedar-policy-mcp-schema-generator-python/tests/test_request_generator.py
+++ b/rust/cedar-policy-mcp-schema-generator-python/tests/test_request_generator.py
@@ -1,0 +1,291 @@
+# Copyright Cedar Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for request generation in the Cedar MCP Schema Generator Python bindings."""
+
+import json
+
+import pytest
+
+from cedar_mcp_schema_generator import (
+    RequestGeneratorError,
+    generate_request,
+    generate_request_or_raise,
+)
+
+STUB = """
+namespace TestServer {
+    @mcp_principal
+    entity User;
+    @mcp_resource
+    entity McpServer;
+    action "call_tool" appliesTo {
+        principal: [User],
+        resource: [McpServer]
+    };
+}
+"""
+
+TOOLS = [
+    {
+        "name": "read_file",
+        "description": "Read a file from disk",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    }
+]
+
+
+class TestGenerateRequest:
+    def test_basic_request(self):
+        result = generate_request(
+            STUB,
+            TOOLS,
+            {"params": {"tool": "read_file", "args": {"path": "/etc/hosts"}}},
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="my-server",
+        )
+        assert result["isOk"] is True
+        assert "alice" in result["principal"]
+        assert "read_file" in result["action"]
+        assert "my-server" in result["resource"]
+        assert result["entitiesJson"] is not None
+
+    def test_request_with_string_input(self):
+        input_json = json.dumps(
+            {"params": {"tool": "read_file", "args": {"path": "/tmp"}}}
+        )
+        result = generate_request(
+            STUB,
+            TOOLS,
+            input_json,
+            principal_type="User",
+            principal_id="bob",
+            resource_type="McpServer",
+            resource_id="server1",
+        )
+        assert result["isOk"] is True
+        assert "bob" in result["principal"]
+
+    def test_namespaced_entities(self):
+        result = generate_request(
+            STUB,
+            TOOLS,
+            {"params": {"tool": "read_file", "args": {"path": "/tmp"}}},
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+        )
+        assert result["isOk"] is True
+        assert result["principal"] == 'TestServer::User::"alice"'
+        assert "TestServer::Action" in result["action"]
+        assert result["resource"] == 'TestServer::McpServer::"s1"'
+
+    def test_entities_json_is_valid(self):
+        result = generate_request(
+            STUB,
+            TOOLS,
+            {"params": {"tool": "read_file", "args": {"path": "/tmp"}}},
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+        )
+        entities = json.loads(result["entitiesJson"])
+        assert isinstance(entities, list)
+
+    def test_invalid_input(self):
+        result = generate_request(
+            STUB,
+            TOOLS,
+            "not valid json",
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+        )
+        assert result["isOk"] is False
+        assert "Invalid tool input" in result["error"]
+
+    def test_invalid_stub(self):
+        result = generate_request(
+            "invalid schema",
+            TOOLS,
+            {"params": {"tool": "read_file", "args": {"path": "/tmp"}}},
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+        )
+        assert result["isOk"] is False
+        assert "Schema error" in result["error"]
+
+    def test_invalid_tools(self):
+        result = generate_request(
+            STUB,
+            "not valid json",
+            {"params": {"tool": "read_file", "args": {"path": "/tmp"}}},
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+        )
+        assert result["isOk"] is False
+        assert "Invalid tool descriptions" in result["error"]
+
+    def test_invalid_config(self):
+        result = generate_request(
+            STUB,
+            TOOLS,
+            {"params": {"tool": "read_file", "args": {"path": "/tmp"}}},
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+            config={"badField": True},
+        )
+        assert result["isOk"] is False
+        assert "Invalid config" in result["error"]
+
+    def test_multi_tool_request(self):
+        tools = [
+            {
+                "name": "read_file",
+                "description": "Read a file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            },
+            {
+                "name": "write_file",
+                "description": "Write a file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["path", "content"],
+                },
+            },
+        ]
+        result = generate_request(
+            STUB,
+            tools,
+            {
+                "params": {
+                    "tool": "write_file",
+                    "args": {"path": "/tmp/out", "content": "hello"},
+                }
+            },
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+        )
+        assert result["isOk"] is True
+        assert "write_file" in result["action"]
+
+    def test_nested_object_input_produces_entities(self):
+        tools = [
+            {
+                "name": "ingest",
+                "description": "Ingest a record",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "metadata": {
+                            "type": "object",
+                            "properties": {
+                                "source": {"type": "string"},
+                                "region": {"type": "string"},
+                            },
+                            "required": ["source"],
+                        },
+                        "score": {"type": "number"},
+                        "note": {"type": "string"},
+                    },
+                    "required": ["metadata", "score"],
+                },
+            }
+        ]
+        result = generate_request(
+            STUB,
+            tools,
+            {
+                "params": {
+                    "tool": "ingest",
+                    "args": {
+                        "metadata": {"source": "sensor-42", "region": "us-east"},
+                        "score": 0.87,
+                        "note": "ok",
+                    },
+                }
+            },
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+        )
+        assert result["isOk"] is True
+        entities = json.loads(result["entitiesJson"])
+        assert len(entities) > 0
+
+    def test_config_with_request(self):
+        result = generate_request(
+            STUB,
+            TOOLS,
+            {"params": {"tool": "read_file", "args": {"path": "/tmp"}}},
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="s1",
+            config={"numbersAsDecimal": True},
+        )
+        assert result["isOk"] is True
+
+
+class TestGenerateRequestOrRaise:
+    def test_success(self):
+        result = generate_request_or_raise(
+            STUB,
+            TOOLS,
+            {"params": {"tool": "read_file", "args": {"path": "/tmp"}}},
+            principal_type="User",
+            principal_id="alice",
+            resource_type="McpServer",
+            resource_id="my-server",
+        )
+        assert result["isOk"] is True
+        assert "alice" in result["principal"]
+
+    def test_raises_on_error(self):
+        with pytest.raises(RequestGeneratorError, match="Invalid tool input"):
+            generate_request_or_raise(
+                STUB,
+                TOOLS,
+                "bad json",
+                principal_type="User",
+                principal_id="alice",
+                resource_type="McpServer",
+                resource_id="s1",
+            )

--- a/rust/cedar-policy-mcp-schema-generator-python/tests/test_schema_generator.py
+++ b/rust/cedar-policy-mcp-schema-generator-python/tests/test_schema_generator.py
@@ -1,0 +1,209 @@
+# Copyright Cedar Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Cedar MCP Schema Generator Python bindings."""
+
+import json
+
+import pytest
+
+from cedar_mcp_schema_generator import (
+    SchemaGeneratorError,
+    generate_schema,
+    generate_schema_or_raise,
+)
+
+STUB = """
+namespace TestServer {
+    @mcp_principal
+    entity User;
+    @mcp_resource
+    entity McpServer;
+    action "call_tool" appliesTo {
+        principal: [User],
+        resource: [McpServer]
+    };
+}
+"""
+
+TOOLS = [
+    {
+        "name": "read_file",
+        "description": "Read a file from disk",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    }
+]
+
+
+class TestGenerateSchema:
+    def test_basic_schema_generation(self):
+        result = generate_schema(STUB, TOOLS)
+        assert result["isOk"] is True
+        assert result["error"] is None
+        assert "read_file" in result["schema"]
+        assert result["schemaJson"] is not None
+
+    def test_schema_json_is_valid(self):
+        result = generate_schema(STUB, TOOLS)
+        schema_json = json.loads(result["schemaJson"])
+        assert isinstance(schema_json, dict)
+
+    def test_tools_as_json_string(self):
+        result = generate_schema(STUB, json.dumps(TOOLS))
+        assert result["isOk"] is True
+        assert "read_file" in result["schema"]
+
+    def test_empty_tools(self):
+        result = generate_schema(STUB, [])
+        assert result["isOk"] is True
+
+    def test_invalid_stub(self):
+        result = generate_schema("not a valid schema", TOOLS)
+        assert result["isOk"] is False
+        assert result["error"] is not None
+
+    def test_invalid_tools_json(self):
+        result = generate_schema(STUB, "not valid json")
+        assert result["isOk"] is False
+        assert "Invalid tool descriptions" in result["error"]
+
+    def test_invalid_config(self):
+        result = generate_schema(STUB, TOOLS, config={"unknownField": True})
+        assert result["isOk"] is False
+        assert "Invalid config" in result["error"]
+
+    def test_config_numbers_as_decimal(self):
+        tools = [
+            {
+                "name": "calculate",
+                "description": "Perform calculation",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"value": {"type": "number"}},
+                },
+            }
+        ]
+        result = generate_schema(
+            STUB, tools, config={"numbersAsDecimal": True, "includeOutputs": False}
+        )
+        assert result["isOk"] is True
+        assert result["schema"] is not None
+
+    def test_config_flatten_namespaces(self):
+        result = generate_schema(STUB, TOOLS, config={"flattenNamespaces": True})
+        assert result["isOk"] is True
+
+    def test_config_all_options(self):
+        result = generate_schema(
+            STUB,
+            TOOLS,
+            config={
+                "includeOutputs": True,
+                "objectsAsRecords": True,
+                "eraseAnnotations": False,
+                "flattenNamespaces": True,
+                "numbersAsDecimal": True,
+                "deduplicateEntityTypes": True,
+            },
+        )
+        assert result["isOk"] is True
+
+    def test_multi_tool(self):
+        tools = [
+            {
+                "name": "search",
+                "description": "Search for items",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "integer"},
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "get_item",
+                "description": "Get a specific item",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "include_metadata": {"type": "boolean"},
+                    },
+                    "required": ["id"],
+                },
+            },
+        ]
+        result = generate_schema(STUB, tools)
+        assert result["isOk"] is True
+        assert "search" in result["schema"]
+        assert "get_item" in result["schema"]
+
+    def test_nested_object_tool(self):
+        tools = [
+            {
+                "name": "create_record",
+                "description": "Create a record",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "metadata": {
+                            "type": "object",
+                            "properties": {
+                                "created_by": {"type": "string"},
+                                "priority": {"type": "integer"},
+                            },
+                        },
+                    },
+                    "required": ["name"],
+                },
+            }
+        ]
+        result = generate_schema(STUB, tools)
+        assert result["isOk"] is True
+
+    def test_array_property(self):
+        tools = [
+            {
+                "name": "process_batch",
+                "description": "Process items",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "items": {"type": "array", "items": {"type": "string"}}
+                    },
+                    "required": ["items"],
+                },
+            }
+        ]
+        result = generate_schema(STUB, tools)
+        assert result["isOk"] is True
+        assert "process_batch" in result["schema"]
+
+
+class TestGenerateSchemaOrRaise:
+    def test_success(self):
+        result = generate_schema_or_raise(STUB, TOOLS)
+        assert result["isOk"] is True
+        assert "read_file" in result["schema"]
+
+    def test_raises_on_error(self):
+        with pytest.raises(SchemaGeneratorError, match="failed to parse"):
+            generate_schema_or_raise("invalid", TOOLS)


### PR DESCRIPTION

## Description of changes

This PR adds `rust/cedar-policy-mcp-schema-generator/` that provides Python bindings for the Cedar MCP Schema Generator, following the same architecture as the existing `rust/cedar-policy-mcp-schema-generator-wasm/` package for JavaScript.

**What's included:**
- `src/lib.rs`:Thin PyO3 wrapper exposing `generate_schema` & `generate_request`
- `python/cedar_mcp_schema_generator/__init__.py`: Pythonic wrapper
- `tests/`: tests mirroring `tests/node/test.mjs`
- `pyproject.toml`: maturin build backend configuration
- `README.md`: Usage documentation with examples

**What's not included:**
- CI workflow 
- PyPI publish workflow
Will be including in follow up PR

## Issue #, if available

https://github.com/cedar-policy/cedar-for-agents/issues/138

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to any crates in this repository (e.g., addition of a new API).
  * `cedar-policy-mcp-schema-generator-python` is a new crate, v0.6.0 to match the existing packages

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code. Will add change log in CI/Pypi publish follow up