### PR TITLE
chore: add ci and PyPI publish workflows for python bindings

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -1,0 +1,61 @@
+name: Python Integration Tests
+on:
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  build_and_test:
+    name: Python Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Configure Rust toolchain
+        run: rustup update stable && rustup default stable
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Create virtual environment
+        run: python -m venv .venv
+        working-directory: rust/cedar-policy-mcp-schema-generator-python
+
+      - name: Install maturin
+        run: .venv/bin/pip install maturin[patchelf]
+        working-directory: rust/cedar-policy-mcp-schema-generator-python
+
+      - name: Build and install package
+        run: .venv/bin/maturin develop --extras dev
+        working-directory: rust/cedar-policy-mcp-schema-generator-python
+
+      - name: Run tests
+        run: .venv/bin/pytest tests/ -v
+        working-directory: rust/cedar-policy-mcp-schema-generator-python
+
+  lint:
+    name: Python Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Install ruff
+        run: pip install ruff==0.14.14
+
+      - name: Check formatting
+        run: ruff format --check cedar_mcp_schema_generator/ tests/
+        working-directory: rust/cedar-policy-mcp-schema-generator-python
+
+      - name: Check linting
+        run: ruff check cedar_mcp_schema_generator/ tests/
+        working-directory: rust/cedar-policy-mcp-schema-generator-python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,6 @@ jobs:
 
   wasm_integration_tests:
     uses: ./.github/workflows/wasm_integration_tests.yml
+
+  build_and_test_python:
+    uses: ./.github/workflows/build_and_test_python.yml

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -21,3 +21,6 @@ jobs:
 
   wasm_integration_tests:
     uses: ./.github/workflows/wasm_integration_tests.yml
+
+  build_and_test_python:
+    uses: ./.github/workflows/build_and_test_python.yml

--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -1,0 +1,132 @@
+# This workflow publishes the Python bindings for cedar-policy-mcp-schema-generator
+# to PyPI. It must be triggered from main and pointed at a pre-created release tag.
+name: Publish MCP schema generator Python to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: >
+          GitHub tag to release. Must be of the form
+          'cedar-mcp-schema-generator-python-v<MAJOR>.<MINOR>.<PATCH>'.
+
+permissions: read-all
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch
+        if: github.ref != 'refs/heads/main'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: core.setFailed('This workflow must be triggered from the "main" branch.')
+
+      - name: Validate tag format
+        shell: bash
+        run: |
+          REGEX_PATTERN='^cedar-mcp-schema-generator-python-v[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ ! "$TAG_NAME" =~ $REGEX_PATTERN ]]; then
+            echo "Specified tag must match $REGEX_PATTERN"
+            exit 1
+          fi
+        env:
+          TAG_NAME: ${{ inputs.tag }}
+
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Validate package version
+        shell: bash
+        run: |
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' rust/cedar-policy-mcp-schema-generator-python/pyproject.toml | head -1)
+          EXPECTED="cedar-mcp-schema-generator-python-v${VERSION}"
+          if [[ "$EXPECTED" != "$TAG_NAME" ]]; then
+            echo "Tag $TAG_NAME does not match pyproject.toml version $VERSION"
+            echo "Expected $EXPECTED"
+            exit 1
+          fi
+        env:
+          TAG_NAME: ${{ inputs.tag }}
+
+  build-wheels:
+    needs: [validate]
+    name: Build wheels (${{ matrix.os }} / ${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64
+          - os: ubuntu-latest
+            target: aarch64
+          - os: macos-latest
+            target: x86_64
+          - os: macos-latest
+            target: aarch64
+          - os: windows-latest
+            target: x64
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          manylinux: auto
+          working-directory: rust/cedar-policy-mcp-schema-generator-python
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wheel-${{ matrix.os }}-${{ matrix.target }}
+          path: rust/cedar-policy-mcp-schema-generator-python/dist/
+
+  build-sdist:
+    needs: [validate]
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        with:
+          command: sdist
+          args: --out dist
+          working-directory: rust/cedar-policy-mcp-schema-generator-python
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sdist
+          path: rust/cedar-policy-mcp-schema-generator-python/dist/
+
+  publish:
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist/

--- a/rust/cedar-policy-mcp-schema-generator-python/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator-python/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.0] - 2026-06-15
+
+Initial release of `cedar-mcp-schema-generator`, the Python bindings for crate `cedar-policy-mcp-schema-generator` v0.6.0.


### PR DESCRIPTION
## Description of changes

Adds CI and release plumbing for the Python bindings package introduced in #139:

- **`.github/workflows/build_and_test_python.yml`**: builds the native extension via `maturin develop`, runs pytest across python 3.9–3.13, and runs linting via ruff.
- **`.github/workflows/publish_python.yml`**: Manual `workflow_dispatch` workflow that validates a release tag against `pyproject.toml`, builds multi-platform wheels (linux x86_64/aarch64, macos x86_64/aarch64, windows x64) and an sdist, then publishes to pypi via oidc.
- **`.github/workflows/ci.yaml`** and **`.github/workflows/nightly_build.yml`**: just call the new python CI workflow.

### PyPI Trusted Publisher setup

A pending publisher has been configured on pypi.org for `cedar-mcp-schema-generator` pointing at this repo's `publish_python.yml` workflow and `release` environment. Ownership will be transferred to the Cedar team after first publish.

## Issue #, if available

Follow-up to #139.

## Checklist for requesting a review

The change in this PR is:

- [x] A change "invisible" to users (e.g., documentation, changes to non public-facing "internal" APIs)

I confirm that this PR:

- [x] Created a new changelog!