### PR TITLE
update package name to match others (#143)

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -10,7 +10,7 @@ on:
         type: string
         description: >
           GitHub tag to release. Must be of the form
-          'cedar-mcp-schema-generator-python-v<MAJOR>.<MINOR>.<PATCH>'.
+          'cedar-policy-mcp-schema-generator-python-v<MAJOR>.<MINOR>.<PATCH>'.
 
 permissions: read-all
 
@@ -27,7 +27,7 @@ jobs:
       - name: Validate tag format
         shell: bash
         run: |
-          REGEX_PATTERN='^cedar-mcp-schema-generator-python-v[0-9]+\.[0-9]+\.[0-9]+$'
+          REGEX_PATTERN='^cedar-policy-mcp-schema-generator-python-v[0-9]+\.[0-9]+\.[0-9]+$'
           if [[ ! "$TAG_NAME" =~ $REGEX_PATTERN ]]; then
             echo "Specified tag must match $REGEX_PATTERN"
             exit 1
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' rust/cedar-policy-mcp-schema-generator-python/pyproject.toml | head -1)
-          EXPECTED="cedar-mcp-schema-generator-python-v${VERSION}"
+          EXPECTED="cedar-policy-mcp-schema-generator-python-v${VERSION}"
           if [[ "$EXPECTED" != "$TAG_NAME" ]]; then
             echo "Tag $TAG_NAME does not match pyproject.toml version $VERSION"
             echo "Expected $EXPECTED"

--- a/rust/cedar-policy-mcp-schema-generator-python/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator-python/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0] - 2026-06-15
 
-Initial release of `cedar-mcp-schema-generator`, the Python bindings for crate `cedar-policy-mcp-schema-generator` v0.6.0.
+Initial release of `cedar-policy-mcp-schema-generator`, the Python bindings for crate `cedar-policy-mcp-schema-generator` v0.6.0.

--- a/rust/cedar-policy-mcp-schema-generator-python/pyproject.toml
+++ b/rust/cedar-policy-mcp-schema-generator-python/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "cedar-mcp-schema-generator"
+name = "cedar-policy-mcp-schema-generator"
 version = "0.6.0"
-description = "Python bindings for the Cedar MCP Schema Generator"
+description = "Python bindings for the Cedar Policy MCP Schema Generator"
 requires-python = ">=3.9"
 license = "Apache-2.0"
 keywords = ["cedar", "authorization", "mcp", "schema", "agents"]


### PR DESCRIPTION
Cherry-pick of the python package rename onto release branch of python 0.6.x bindings