### PR TITLE
Fix aarch64 wheel build by adding --find-interpreter flag 

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -76,11 +76,16 @@ jobs:
         with:
           ref: refs/tags/${{ inputs.tag }}
 
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.9"
+
       - name: Build wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --out dist --find-interpreter
           manylinux: auto
           working-directory: rust/cedar-policy-mcp-schema-generator-python
 


### PR DESCRIPTION
## Description of changes

Fix the publish workflow's wheel build for cross-compilation targets (aarch64). The `maturin-action` Docker container has Python interpreters installed but maturin needs `--find-interpreter` to locate them. Also adds `actions/setup-python` before the build step to ensure interpreters are available on non-containerized targets (macOS, Windows), matching the official `maturin generate-ci` template.

Verified locally by building aarch64 wheels inside the `manylinux2014-cross:aarch64` container.

## Issue #, if available

Follow-up to #140.

## Checklist for requesting a review

The change in this PR is:

- [x] A change "invisible" to users (e.g., documentation, changes to non public-facing "internal" APIs)

I confirm that this PR:

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.