### PR TITLE
fix in build_and_test_rust condition syntax

### DIFF
--- a/.github/workflows/build_and_test_rust.yml
+++ b/.github/workflows/build_and_test_rust.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: df -h
       - name: Set environment variables for coverage collection
-        if: ${{ inputs.collect_coverage }} && ${{ matrix.toolchain }} == 'stable'
+        if: ${{ inputs.collect_coverage && matrix.toolchain == 'stable' }}
         shell: bash
         run: |
           echo "RUSTFLAGS=${RUSTFLAGS} -C instrument-coverage" >> $GITHUB_ENV
@@ -74,7 +74,7 @@ jobs:
         working-directory: rust/
 
       - name: Create a coverage report
-        if: ${{ inputs.collect_coverage }} && ${{ matrix.toolchain }} == 'stable'
+        if: ${{ inputs.collect_coverage && matrix.toolchain == 'stable' }}
         uses: ./.github/actions/create_coverage_reports
         with:
           retention-days: ${{ inputs.retention-days }}


### PR DESCRIPTION
Minor fix in the CI condition's syntax on generating coverage reports.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to any crates in this repository (e.g., changes to the signature of an existing API).
  * List all crates requiring a major version bump here
- [ ] A backwards-compatible change requiring a minor version bump to any crates in this repository (e.g., addition of a new API).
  * List all crates requiring a minor version bump here
- [ ] A bug fix or other functionality change requiring a patch to any crates.
- [x] A change "invisible" to users (e.g., documentation, changes to non public-facing "internal" APIs)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.