### PR TITLE
feat: add rust cedar policy builder

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "ascii-canvas"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +260,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cedar-policy"
+version = "4.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fdd98501120bc31fc09f92d3f58c489f4ee4b846904109ac63dd8256de7b84d"
+dependencies = [
+ "cedar-policy-core",
+ "cedar-policy-formatter",
+ "itertools 0.14.0",
+ "linked-hash-map",
+ "miette",
+ "ref-cast",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
+name = "cedar-policy-agent-builder"
+version = "0.1.0"
+dependencies = [
+ "cedar-policy",
+ "cedar-policy-core",
+ "cedar-policy-mcp-schema-generator",
+ "mcp-tools-sdk",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cedar-policy-core"
 version = "4.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +318,21 @@ dependencies = [
  "stacker",
  "thiserror",
  "unicode-security",
+]
+
+[[package]]
+name = "cedar-policy-formatter"
+version = "4.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6c28be47d77dcbc04c2a80181a2c0db9725ed60d24832c6401396cc2ae114b"
+dependencies = [
+ "cedar-policy-core",
+ "itertools 0.14.0",
+ "logos",
+ "miette",
+ "pretty",
+ "regex",
+ "smol_str",
 ]
 
 [[package]]
@@ -582,6 +636,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,9 +702,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -707,12 +767,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -870,6 +930,38 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "mcp-tools-sdk"
@@ -1056,7 +1148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -1123,6 +1215,17 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec",
+ "typed-arena",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1345,6 +1448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,7 +1489,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -1399,7 +1508,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -1603,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1645,6 +1754,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+	"cedar-policy-agent-builder",
 	"cedar-policy-mcp-schema-generator",
 	"cedar-policy-mcp-schema-generator-python",
 	"cedar-policy-mcp-schema-generator-wasm",

--- a/rust/cedar-policy-agent-builder/Cargo.toml
+++ b/rust/cedar-policy-agent-builder/Cargo.toml
@@ -14,8 +14,7 @@ repository.workspace = true
 [dependencies]
 cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator" }
 mcp-tools-sdk = { path = "../mcp-tools-sdk" }
-cedar-policy = "4"
-cedar-policy-core = "=4.11.2"
+cedar-policy = ">= 4.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/rust/cedar-policy-agent-builder/Cargo.toml
+++ b/rust/cedar-policy-agent-builder/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "cedar-policy-agent-builder"
+description = "Generates Cedar policies, entities, and schemas from declarative agent authorization configuration."
+version = "0.1.0"
+
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+categories.workspace = true
+keywords.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator" }
+mcp-tools-sdk = { path = "../mcp-tools-sdk" }
+cedar-policy = "4"
+cedar-policy-core = "=4.11.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0"
+
+[lints]
+workspace = true

--- a/rust/cedar-policy-agent-builder/src/builder.rs
+++ b/rust/cedar-policy-agent-builder/src/builder.rs
@@ -1,0 +1,329 @@
+use crate::config::*;
+use crate::BuildResult;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum BuilderError {
+    #[error("time_window requires hour_start ({start}) < hour_end ({end})")]
+    InvalidTimeWindow { start: u8, end: u8 },
+    #[error("hour_end ({0}) must be <= 24")]
+    HourOutOfRange(u8),
+}
+
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct CedarAgentPolicyBuilder {
+    config: CedarAgentConfig,
+}
+
+impl Default for CedarAgentPolicyBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CedarAgentPolicyBuilder {
+    pub fn new() -> Self {
+        Self {
+            config: CedarAgentConfig::default(),
+        }
+    }
+
+    pub fn namespace(mut self, ns: &str) -> Self {
+        self.config.namespace = ns.to_string();
+        self
+    }
+
+    pub fn principal(mut self, key: &str, principal_type: &str) -> Self {
+        self.config.principal = PrincipalConfig {
+            key: key.to_string(),
+            principal_type: principal_type.to_string(),
+        };
+        self
+    }
+
+    pub fn resource(mut self, resource_type: &str, id: &str) -> Self {
+        self.config.resource = Some(ResourceConfig {
+            resource_type: resource_type.to_string(),
+            id: id.to_string(),
+        });
+        self
+    }
+
+    pub fn role(mut self, name: &str, tools: &[&str]) -> Self {
+        self.config.roles.get_or_insert_with(BTreeMap::new).insert(
+            name.to_string(),
+            tools.iter().map(|t| (*t).to_string()).collect(),
+        );
+        self
+    }
+
+    pub fn user(mut self, id: &str, roles: &[&str]) -> Self {
+        self.config.users.get_or_insert_with(BTreeMap::new).insert(
+            id.to_string(),
+            roles.iter().map(|r| (*r).to_string()).collect(),
+        );
+        self
+    }
+
+    pub fn restrict(
+        mut self,
+        tool: &str,
+        allowed_values: BTreeMap<String, Vec<serde_json::Value>>,
+    ) -> Self {
+        self.config
+            .restrictions
+            .get_or_insert_with(BTreeMap::new)
+            .insert(tool.to_string(), Restriction { allowed_values });
+        self
+    }
+
+    pub fn rate_limit(mut self, tool: &str, max: u64) -> Self {
+        self.config
+            .rate_limits
+            .get_or_insert_with(BTreeMap::new)
+            .insert(tool.to_string(), max);
+        self
+    }
+
+    pub fn time_window(mut self, tool: &str, hours: (u8, u8)) -> Result<Self, BuilderError> {
+        if hours.0 >= hours.1 {
+            return Err(BuilderError::InvalidTimeWindow {
+                start: hours.0,
+                end: hours.1,
+            });
+        }
+        if hours.1 > 24 {
+            return Err(BuilderError::HourOutOfRange(hours.1));
+        }
+        self.config
+            .time_windows
+            .get_or_insert_with(BTreeMap::new)
+            .insert(
+                tool.to_string(),
+                TimeWindow {
+                    hour_start: hours.0,
+                    hour_end: hours.1,
+                },
+            );
+        Ok(self)
+    }
+
+    pub fn deny_in_env(mut self, env: &str, tools: &[&str]) -> Self {
+        self.config
+            .deny_in_env
+            .get_or_insert_with(BTreeMap::new)
+            .insert(
+                env.to_string(),
+                tools.iter().map(|t| (*t).to_string()).collect(),
+            );
+        self
+    }
+
+    pub fn consent_all(mut self, tool: &str) -> Self {
+        self.config
+            .consent
+            .get_or_insert_with(BTreeMap::new)
+            .insert(tool.to_string(), ConsentScope::AllRoles(true));
+        self
+    }
+
+    pub fn consent_for_roles(mut self, tool: &str, roles: &[&str]) -> Self {
+        self.config
+            .consent
+            .get_or_insert_with(BTreeMap::new)
+            .insert(
+                tool.to_string(),
+                ConsentScope::SpecificRoles(roles.iter().map(|r| (*r).to_string()).collect()),
+            );
+        self
+    }
+
+    pub fn tool(mut self, definition: McpToolDefinition) -> Self {
+        self.config
+            .tools
+            .get_or_insert_with(Vec::new)
+            .push(definition);
+        self
+    }
+
+    pub fn build(self) -> BuildResult {
+        crate::build(&self.config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cedar_policy::PolicySet;
+
+    fn assert_policies_parse(result: &crate::BuildResult) {
+        if !result.policies.is_empty() {
+            result.policies.parse::<PolicySet>().unwrap_or_else(|e| {
+                panic!(
+                    "generated policies failed to parse:\n{}\nerror: {e}",
+                    result.policies
+                )
+            });
+        }
+    }
+
+    #[test]
+    fn test_builder_basic() {
+        let result = CedarAgentPolicyBuilder::new()
+            .role("admin", &["*"])
+            .user("alice", &["admin"])
+            .build();
+
+        assert!(result
+            .policies
+            .contains("principal in Agent::Role::\"admin\""));
+        assert!(result.entities.iter().any(|e| e.uid.id == "alice"));
+        assert!(result.entities.iter().any(|e| e.uid.id == "admin"));
+    }
+
+    #[test]
+    fn test_builder_with_namespace() {
+        let result = CedarAgentPolicyBuilder::new()
+            .namespace("MyApp")
+            .role("viewer", &["read"])
+            .build();
+
+        assert!(result.policies.contains("MyApp::Role::\"viewer\""));
+        assert!(result.policies.contains("MyApp::Action::\"read\""));
+    }
+
+    #[test]
+    fn test_builder_chaining() {
+        let result = CedarAgentPolicyBuilder::new()
+            .namespace("Agent")
+            .principal("sub", "User")
+            .role("admin", &["*"])
+            .role("analyst", &["search"])
+            .user("alice", &["admin"])
+            .user("bob", &["analyst"])
+            .rate_limit("send_email", 5)
+            .time_window("*", (9, 17))
+            .unwrap()
+            .consent_all("send_email")
+            .deny_in_env("production", &["delete"])
+            .build();
+
+        assert!(result.policies.contains("Role::\"admin\""));
+        assert!(result.policies.contains("Role::\"analyst\""));
+        assert!(result.policies.contains("call_count_send_email >= 5"));
+        assert!(result.policies.contains("hour_utc < 9"));
+        assert!(result.policies.contains("user_consent"));
+        assert!(result.policies.contains("\"production\""));
+    }
+
+    #[test]
+    fn test_builder_default() {
+        let builder = CedarAgentPolicyBuilder::default();
+        let result = builder.build();
+        assert!(result.policies.is_empty());
+        assert_eq!(result.entities.len(), 1); // just the default resource
+    }
+
+    #[test]
+    fn test_all_policy_types_parse_as_valid_cedar() {
+        let result = CedarAgentPolicyBuilder::new()
+            .namespace("Agent")
+            .principal("sub", "User")
+            .role("admin", &["*"])
+            .role("analyst", &["search", "query"])
+            .user("alice", &["admin"])
+            .user("bob", &["analyst"])
+            .rate_limit("send_email", 5)
+            .rate_limit("*", 100)
+            .time_window("*", (9, 17))
+            .unwrap()
+            .consent_all("send_email")
+            .consent_for_roles("deploy", &["admin"])
+            .deny_in_env("production", &["delete"])
+            .restrict(
+                "query",
+                BTreeMap::from([("db".to_string(), vec![serde_json::json!("analytics")])]),
+            )
+            .build();
+
+        assert_policies_parse(&result);
+    }
+
+    #[test]
+    fn test_basic_build_parses() {
+        let result = CedarAgentPolicyBuilder::new()
+            .role("admin", &["*"])
+            .user("alice", &["admin"])
+            .build();
+
+        assert_policies_parse(&result);
+    }
+
+    #[test]
+    fn test_time_window_rejects_inverted() {
+        let err = CedarAgentPolicyBuilder::new()
+            .time_window("*", (17, 9))
+            .unwrap_err();
+        assert!(matches!(err, BuilderError::InvalidTimeWindow { .. }));
+    }
+
+    #[test]
+    fn test_time_window_rejects_over_24() {
+        let err = CedarAgentPolicyBuilder::new()
+            .time_window("*", (9, 25))
+            .unwrap_err();
+        assert!(matches!(err, BuilderError::HourOutOfRange(25)));
+    }
+
+    #[test]
+    fn test_builder_with_tool_definitions() {
+        let result = CedarAgentPolicyBuilder::new()
+            .role("admin", &["*"])
+            .tool(McpToolDefinition {
+                name: "search".to_string(),
+                description: Some("Search things".to_string()),
+                input_schema: serde_json::json!({"type": "object", "properties": {"q": {"type": "string"}}}),
+                output_schema: None,
+            })
+            .build();
+
+        assert!(result.schema.is_some());
+        assert!(result.schema_errors.is_empty());
+    }
+
+    #[test]
+    fn test_builder_resource_custom() {
+        let result = CedarAgentPolicyBuilder::new()
+            .resource("Gateway", "prod")
+            .role("admin", &["*"])
+            .build();
+
+        let resource = result.entities.iter().find(|e| e.uid.id == "prod").unwrap();
+        assert_eq!(resource.uid.entity_type, "Agent::Gateway");
+    }
+
+    #[test]
+    fn test_builder_consent_for_roles_in_chain() {
+        let result = CedarAgentPolicyBuilder::new()
+            .role("admin", &["*"])
+            .role("analyst", &["search", "deploy"])
+            .consent_for_roles("deploy", &["admin"])
+            .build();
+
+        assert!(result.policies.contains("user_consent"));
+        assert!(result.policies.contains("Role::\"admin\""));
+    }
+
+    #[test]
+    fn test_builder_time_window_per_tool() {
+        let result = CedarAgentPolicyBuilder::new()
+            .role("admin", &["*"])
+            .time_window("deploy", (9, 17))
+            .unwrap()
+            .build();
+
+        assert!(result.policies.contains("Action::\"deploy\""));
+        assert!(result.policies.contains("hour_utc"));
+    }
+}

--- a/rust/cedar-policy-agent-builder/src/builder.rs
+++ b/rust/cedar-policy-agent-builder/src/builder.rs
@@ -8,6 +8,14 @@ pub enum BuilderError {
     InvalidTimeWindow { start: u8, end: u8 },
     #[error("hour_end ({0}) must be <= 24")]
     HourOutOfRange(u8),
+    #[error("\"{0}\" is not a valid Cedar identifier")]
+    InvalidIdentifier(String),
+}
+
+fn validate_cedar_ident(s: &str) -> Result<(), BuilderError> {
+    s.parse::<cedar_policy_core::ast::Id>()
+        .map(|_| ())
+        .map_err(|_| BuilderError::InvalidIdentifier(s.to_string()))
 }
 
 #[derive(Debug, Clone)]
@@ -29,25 +37,28 @@ impl CedarAgentPolicyBuilder {
         }
     }
 
-    pub fn namespace(mut self, ns: &str) -> Self {
+    pub fn namespace(mut self, ns: &str) -> Result<Self, BuilderError> {
+        validate_cedar_ident(ns)?;
         self.config.namespace = ns.to_string();
-        self
+        Ok(self)
     }
 
-    pub fn principal(mut self, key: &str, principal_type: &str) -> Self {
+    pub fn principal(mut self, key: &str, principal_type: &str) -> Result<Self, BuilderError> {
+        validate_cedar_ident(principal_type)?;
         self.config.principal = PrincipalConfig {
             key: key.to_string(),
             principal_type: principal_type.to_string(),
         };
-        self
+        Ok(self)
     }
 
-    pub fn resource(mut self, resource_type: &str, id: &str) -> Self {
+    pub fn resource(mut self, resource_type: &str, id: &str) -> Result<Self, BuilderError> {
+        validate_cedar_ident(resource_type)?;
         self.config.resource = Some(ResourceConfig {
             resource_type: resource_type.to_string(),
             id: id.to_string(),
         });
-        self
+        Ok(self)
     }
 
     pub fn role(mut self, name: &str, tools: &[&str]) -> Self {
@@ -186,6 +197,7 @@ mod tests {
     fn test_builder_with_namespace() {
         let result = CedarAgentPolicyBuilder::new()
             .namespace("MyApp")
+            .unwrap()
             .role("viewer", &["read"])
             .build();
 
@@ -197,7 +209,9 @@ mod tests {
     fn test_builder_chaining() {
         let result = CedarAgentPolicyBuilder::new()
             .namespace("Agent")
+            .unwrap()
             .principal("sub", "User")
+            .unwrap()
             .role("admin", &["*"])
             .role("analyst", &["search"])
             .user("alice", &["admin"])
@@ -229,7 +243,9 @@ mod tests {
     fn test_all_policy_types_parse_as_valid_cedar() {
         let result = CedarAgentPolicyBuilder::new()
             .namespace("Agent")
+            .unwrap()
             .principal("sub", "User")
+            .unwrap()
             .role("admin", &["*"])
             .role("analyst", &["search", "query"])
             .user("alice", &["admin"])
@@ -296,6 +312,7 @@ mod tests {
     fn test_builder_resource_custom() {
         let result = CedarAgentPolicyBuilder::new()
             .resource("Gateway", "prod")
+            .unwrap()
             .role("admin", &["*"])
             .build();
 
@@ -325,5 +342,35 @@ mod tests {
 
         assert!(result.policies.contains("Action::\"deploy\""));
         assert!(result.policies.contains("hour_utc"));
+    }
+
+    #[test]
+    fn test_namespace_rejects_reserved_word() {
+        let err = CedarAgentPolicyBuilder::new().namespace("if").unwrap_err();
+        assert!(matches!(err, BuilderError::InvalidIdentifier(_)));
+    }
+
+    #[test]
+    fn test_namespace_rejects_invalid_chars() {
+        let err = CedarAgentPolicyBuilder::new()
+            .namespace("my-ns")
+            .unwrap_err();
+        assert!(matches!(err, BuilderError::InvalidIdentifier(_)));
+    }
+
+    #[test]
+    fn test_principal_type_rejects_reserved_word() {
+        let err = CedarAgentPolicyBuilder::new()
+            .principal("sub", "if")
+            .unwrap_err();
+        assert!(matches!(err, BuilderError::InvalidIdentifier(_)));
+    }
+
+    #[test]
+    fn test_resource_type_rejects_invalid() {
+        let err = CedarAgentPolicyBuilder::new()
+            .resource("123bad", "id")
+            .unwrap_err();
+        assert!(matches!(err, BuilderError::InvalidIdentifier(_)));
     }
 }

--- a/rust/cedar-policy-agent-builder/src/builder.rs
+++ b/rust/cedar-policy-agent-builder/src/builder.rs
@@ -13,7 +13,7 @@ pub enum BuilderError {
 }
 
 fn validate_cedar_ident(s: &str) -> Result<(), BuilderError> {
-    s.parse::<cedar_policy_core::ast::Id>()
+    cedar_policy::pst::Id::new(s)
         .map(|_| ())
         .map_err(|_| BuilderError::InvalidIdentifier(s.to_string()))
 }

--- a/rust/cedar-policy-agent-builder/src/builder.rs
+++ b/rust/cedar-policy-agent-builder/src/builder.rs
@@ -2,12 +2,16 @@ use crate::config::*;
 use crate::BuildResult;
 use std::collections::BTreeMap;
 
+/// Errors returned by [`CedarAgentPolicyBuilder`] methods that validate input.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum BuilderError {
+    /// The time window has `hour_start >= hour_end`.
     #[error("time_window requires hour_start ({start}) < hour_end ({end})")]
     InvalidTimeWindow { start: u8, end: u8 },
+    /// The `hour_end` value exceeds 24.
     #[error("hour_end ({0}) must be <= 24")]
     HourOutOfRange(u8),
+    /// The given string is not a valid Cedar identifier (e.g. reserved word, invalid characters).
     #[error("\"{0}\" is not a valid Cedar identifier")]
     InvalidIdentifier(String),
 }
@@ -18,6 +22,24 @@ fn validate_cedar_ident(s: &str) -> Result<(), BuilderError> {
         .map_err(|_| BuilderError::InvalidIdentifier(s.to_string()))
 }
 
+/// Fluent builder for generating Cedar policies, entities, and schemas for agent authorization.
+///
+/// # Example
+///
+/// ```rust
+/// use cedar_policy_agent_builder::CedarAgentPolicyBuilder;
+///
+/// let result = CedarAgentPolicyBuilder::new()
+///     .role("admin", &["*"])
+///     .role("analyst", &["search", "query"])
+///     .user("alice", &["admin"])
+///     .user("bob", &["analyst"])
+///     .rate_limit("search", 100)
+///     .time_window("*", (9, 17)).unwrap()
+///     .build();
+///
+/// assert!(!result.policies.is_empty());
+/// ```
 #[derive(Debug, Clone)]
 #[must_use]
 pub struct CedarAgentPolicyBuilder {
@@ -31,18 +53,27 @@ impl Default for CedarAgentPolicyBuilder {
 }
 
 impl CedarAgentPolicyBuilder {
+    /// Create a new builder with default configuration (namespace `"Agent"`, principal type `"User"`).
     pub fn new() -> Self {
         Self {
             config: CedarAgentConfig::default(),
         }
     }
 
+    /// Set the Cedar namespace for all generated entity types and actions.
+    ///
+    /// Defaults to `"Agent"`. Must be a valid Cedar identifier.
     pub fn namespace(mut self, ns: &str) -> Result<Self, BuilderError> {
         validate_cedar_ident(ns)?;
         self.config.namespace = ns.to_string();
         Ok(self)
     }
 
+    /// Set the principal entity type and the key used to identify principals at runtime.
+    ///
+    /// `key` is the field name in the authorization context that holds the principal ID
+    /// (e.g. `"sub"` for a JWT subject claim). `principal_type` is the Cedar entity type
+    /// name (e.g. `"User"`). Must be a valid Cedar identifier.
     pub fn principal(mut self, key: &str, principal_type: &str) -> Result<Self, BuilderError> {
         validate_cedar_ident(principal_type)?;
         self.config.principal = PrincipalConfig {
@@ -52,6 +83,9 @@ impl CedarAgentPolicyBuilder {
         Ok(self)
     }
 
+    /// Set a custom resource entity type and ID.
+    ///
+    /// Defaults to `Resource::"default"`. The `resource_type` must be a valid Cedar identifier.
     pub fn resource(mut self, resource_type: &str, id: &str) -> Result<Self, BuilderError> {
         validate_cedar_ident(resource_type)?;
         self.config.resource = Some(ResourceConfig {
@@ -61,6 +95,10 @@ impl CedarAgentPolicyBuilder {
         Ok(self)
     }
 
+    /// Define a role with access to the specified tools.
+    ///
+    /// Use `"*"` as a tool name to grant access to all actions.
+    /// Multiple calls add additional roles.
     pub fn role(mut self, name: &str, tools: &[&str]) -> Self {
         self.config.roles.get_or_insert_with(BTreeMap::new).insert(
             name.to_string(),
@@ -69,6 +107,10 @@ impl CedarAgentPolicyBuilder {
         self
     }
 
+    /// Add a user with membership in the specified roles.
+    ///
+    /// The user entity will be created with parent edges to each role entity,
+    /// enabling Cedar's `principal in Role::"name"` pattern.
     pub fn user(mut self, id: &str, roles: &[&str]) -> Self {
         self.config.users.get_or_insert_with(BTreeMap::new).insert(
             id.to_string(),
@@ -77,6 +119,11 @@ impl CedarAgentPolicyBuilder {
         self
     }
 
+    /// Restrict a tool's input fields to specific allowed values.
+    ///
+    /// Generates a `forbid` policy that denies the action unless the input field
+    /// matches one of the allowed values. The map keys are field names from
+    /// `context.input`, and the values are the permitted values for each field.
     pub fn restrict(
         mut self,
         tool: &str,
@@ -89,6 +136,10 @@ impl CedarAgentPolicyBuilder {
         self
     }
 
+    /// Add a rate limit for a tool (or `"*"` for all tools).
+    ///
+    /// Generates a `forbid` policy that denies when the session's call counter
+    /// for this tool reaches `max`. The counter is expected in `context.session`.
     pub fn rate_limit(mut self, tool: &str, max: u64) -> Self {
         self.config
             .rate_limits
@@ -97,6 +148,10 @@ impl CedarAgentPolicyBuilder {
         self
     }
 
+    /// Restrict a tool (or `"*"` for all tools) to a UTC hour window.
+    ///
+    /// `hours` is `(start, end)` where `start < end` and `end <= 24`.
+    /// Actions are denied when `context.session.hour_utc` is outside this range.
     pub fn time_window(mut self, tool: &str, hours: (u8, u8)) -> Result<Self, BuilderError> {
         if hours.0 >= hours.1 {
             return Err(BuilderError::InvalidTimeWindow {
@@ -120,6 +175,9 @@ impl CedarAgentPolicyBuilder {
         Ok(self)
     }
 
+    /// Deny specific tools (or `"*"` for all) in a named environment.
+    ///
+    /// Generates a `forbid` policy conditioned on `context.session.environment == env`.
     pub fn deny_in_env(mut self, env: &str, tools: &[&str]) -> Self {
         self.config
             .deny_in_env
@@ -131,6 +189,10 @@ impl CedarAgentPolicyBuilder {
         self
     }
 
+    /// Require explicit user consent before allowing a tool for any role.
+    ///
+    /// The tool is excluded from role `permit` policies and instead gated behind
+    /// a `context.session.user_consent == true` condition.
     pub fn consent_all(mut self, tool: &str) -> Self {
         self.config
             .consent
@@ -139,6 +201,7 @@ impl CedarAgentPolicyBuilder {
         self
     }
 
+    /// Require user consent for a tool, but only for specific roles.
     pub fn consent_for_roles(mut self, tool: &str, roles: &[&str]) -> Self {
         self.config
             .consent
@@ -150,6 +213,10 @@ impl CedarAgentPolicyBuilder {
         self
     }
 
+    /// Register an MCP tool definition for Cedar schema generation.
+    ///
+    /// When tool definitions are provided, [`BuildResult::schema`] will contain a
+    /// Cedar schema with actions derived from the tool's input/output schemas.
     pub fn tool(mut self, definition: McpToolDefinition) -> Self {
         self.config
             .tools
@@ -158,6 +225,7 @@ impl CedarAgentPolicyBuilder {
         self
     }
 
+    /// Consume the builder and generate Cedar policies, entities, and schema.
     pub fn build(self) -> BuildResult {
         crate::build(&self.config)
     }

--- a/rust/cedar-policy-agent-builder/src/config.rs
+++ b/rust/cedar-policy-agent-builder/src/config.rs
@@ -1,0 +1,127 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrincipalConfig {
+    pub key: String,
+    #[serde(rename = "type", default = "default_principal_type")]
+    pub principal_type: String,
+}
+
+fn default_principal_type() -> String {
+    "User".to_string()
+}
+
+impl Default for PrincipalConfig {
+    fn default() -> Self {
+        Self {
+            key: "user_id".to_string(),
+            principal_type: default_principal_type(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceConfig {
+    #[serde(rename = "type", default = "default_resource_type")]
+    pub resource_type: String,
+    #[serde(default = "default_resource_id")]
+    pub id: String,
+}
+
+fn default_resource_type() -> String {
+    "Resource".to_string()
+}
+
+fn default_resource_id() -> String {
+    "default".to_string()
+}
+
+impl Default for ResourceConfig {
+    fn default() -> Self {
+        Self {
+            resource_type: default_resource_type(),
+            id: default_resource_id(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ConsentScope {
+    AllRoles(bool),
+    SpecificRoles(Vec<String>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Restriction {
+    #[serde(rename = "allowedValues")]
+    pub allowed_values: BTreeMap<String, Vec<serde_json::Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeWindow {
+    #[serde(rename = "hourStart")]
+    pub hour_start: u8,
+    #[serde(rename = "hourEnd")]
+    pub hour_end: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolDefinition {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: serde_json::Value,
+    #[serde(rename = "outputSchema", default)]
+    pub output_schema: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CedarAgentConfig {
+    #[serde(default)]
+    pub principal: PrincipalConfig,
+    #[serde(default)]
+    pub roles: Option<BTreeMap<String, Vec<String>>>,
+    #[serde(default)]
+    pub users: Option<BTreeMap<String, Vec<String>>>,
+    #[serde(default)]
+    pub restrictions: Option<BTreeMap<String, Restriction>>,
+    #[serde(rename = "rateLimits", default)]
+    pub rate_limits: Option<BTreeMap<String, u64>>,
+    #[serde(rename = "timeWindows", default)]
+    pub time_windows: Option<BTreeMap<String, TimeWindow>>,
+    #[serde(rename = "denyInEnv", default)]
+    pub deny_in_env: Option<BTreeMap<String, Vec<String>>>,
+    #[serde(default)]
+    pub consent: Option<BTreeMap<String, ConsentScope>>,
+    #[serde(default)]
+    pub resource: Option<ResourceConfig>,
+    #[serde(default)]
+    pub tools: Option<Vec<McpToolDefinition>>,
+    #[serde(default = "default_namespace")]
+    pub namespace: String,
+}
+
+fn default_namespace() -> String {
+    "Agent".to_string()
+}
+
+impl Default for CedarAgentConfig {
+    fn default() -> Self {
+        Self {
+            principal: PrincipalConfig::default(),
+            roles: None,
+            users: None,
+            restrictions: None,
+            rate_limits: None,
+            time_windows: None,
+            deny_in_env: None,
+            consent: None,
+            resource: None,
+            tools: None,
+            namespace: default_namespace(),
+        }
+    }
+}

--- a/rust/cedar-policy-agent-builder/src/config.rs
+++ b/rust/cedar-policy-agent-builder/src/config.rs
@@ -1,6 +1,12 @@
+//! Configuration types for the Cedar agent policy builder.
+//!
+//! These types define the declarative input that drives policy generation.
+//! They can be deserialized from JSON/YAML or constructed via [`CedarAgentPolicyBuilder`](crate::CedarAgentPolicyBuilder).
+
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// Configuration for the principal (user/agent) entity type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrincipalConfig {
     pub key: String,
@@ -21,6 +27,7 @@ impl Default for PrincipalConfig {
     }
 }
 
+/// Configuration for the resource entity (the thing being accessed).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResourceConfig {
     #[serde(rename = "type", default = "default_resource_type")]
@@ -46,60 +53,88 @@ impl Default for ResourceConfig {
     }
 }
 
+/// Whether consent is required for all roles or specific ones.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ConsentScope {
+    /// `true` = all roles require consent; `false` = no consent required.
     AllRoles(bool),
+    /// Only the listed roles require consent for this tool.
     SpecificRoles(Vec<String>),
 }
 
+/// Input field restrictions for a tool action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Restriction {
+    /// Map of field name to allowed values. The action is denied unless the field matches.
     #[serde(rename = "allowedValues")]
     pub allowed_values: BTreeMap<String, Vec<serde_json::Value>>,
 }
 
+/// A UTC hour window during which an action is permitted.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TimeWindow {
+    /// Start hour (inclusive), 0-23.
     #[serde(rename = "hourStart")]
     pub hour_start: u8,
+    /// End hour (exclusive), 1-24.
     #[serde(rename = "hourEnd")]
     pub hour_end: u8,
 }
 
+/// An MCP tool definition used for Cedar schema generation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolDefinition {
+    /// Tool name (becomes a Cedar action).
     pub name: String,
+    /// Human-readable description.
     #[serde(default)]
     pub description: Option<String>,
+    /// JSON Schema for the tool's input parameters.
     #[serde(rename = "inputSchema")]
     pub input_schema: serde_json::Value,
+    /// Optional JSON Schema for the tool's output.
     #[serde(rename = "outputSchema", default)]
     pub output_schema: Option<serde_json::Value>,
 }
 
+/// Top-level configuration for Cedar agent policy generation.
+///
+/// This is the serializable form of the builder's internal state. It can be
+/// deserialized directly from JSON/YAML for config-file-driven workflows.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CedarAgentConfig {
+    /// Principal (user/agent) entity configuration.
     #[serde(default)]
     pub principal: PrincipalConfig,
+    /// Role definitions: role name → list of permitted tool names (`"*"` = all).
     #[serde(default)]
     pub roles: Option<BTreeMap<String, Vec<String>>>,
+    /// User definitions: user ID → list of role names.
     #[serde(default)]
     pub users: Option<BTreeMap<String, Vec<String>>>,
+    /// Per-tool input field restrictions.
     #[serde(default)]
     pub restrictions: Option<BTreeMap<String, Restriction>>,
+    /// Per-tool (or global `"*"`) invocation count limits.
     #[serde(rename = "rateLimits", default)]
     pub rate_limits: Option<BTreeMap<String, u64>>,
+    /// Per-tool (or global `"*"`) allowed UTC hour windows.
     #[serde(rename = "timeWindows", default)]
     pub time_windows: Option<BTreeMap<String, TimeWindow>>,
+    /// Tools denied in specific environments.
     #[serde(rename = "denyInEnv", default)]
     pub deny_in_env: Option<BTreeMap<String, Vec<String>>>,
+    /// Tools requiring user consent.
     #[serde(default)]
     pub consent: Option<BTreeMap<String, ConsentScope>>,
+    /// Custom resource entity configuration.
     #[serde(default)]
     pub resource: Option<ResourceConfig>,
+    /// MCP tool definitions for schema generation.
     #[serde(default)]
     pub tools: Option<Vec<McpToolDefinition>>,
+    /// Cedar namespace (default: `"Agent"`).
     #[serde(default = "default_namespace")]
     pub namespace: String,
 }

--- a/rust/cedar-policy-agent-builder/src/entities.rs
+++ b/rust/cedar-policy-agent-builder/src/entities.rs
@@ -1,0 +1,189 @@
+use crate::config::CedarAgentConfig;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EntityUid {
+    #[serde(rename = "type")]
+    pub entity_type: String,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EntityJson {
+    pub uid: EntityUid,
+    pub attrs: BTreeMap<String, serde_json::Value>,
+    pub parents: Vec<EntityUid>,
+}
+
+pub fn generate_entities(config: &CedarAgentConfig) -> Vec<EntityJson> {
+    let mut entities = Vec::new();
+    let ns = &config.namespace;
+
+    if let Some(roles) = &config.roles {
+        for role_name in roles.keys() {
+            entities.push(EntityJson {
+                uid: EntityUid {
+                    entity_type: format!("{ns}::Role"),
+                    id: role_name.clone(),
+                },
+                attrs: BTreeMap::new(),
+                parents: Vec::new(),
+            });
+        }
+    }
+
+    if let Some(users) = &config.users {
+        let principal_type = &config.principal.principal_type;
+        for (user_id, roles) in users {
+            entities.push(EntityJson {
+                uid: EntityUid {
+                    entity_type: format!("{ns}::{principal_type}"),
+                    id: user_id.clone(),
+                },
+                attrs: BTreeMap::new(),
+                parents: roles
+                    .iter()
+                    .map(|r| EntityUid {
+                        entity_type: format!("{ns}::Role"),
+                        id: r.clone(),
+                    })
+                    .collect(),
+            });
+        }
+    }
+
+    let resource = config.resource.as_ref();
+    let resource_type = resource
+        .map(|r| r.resource_type.as_str())
+        .unwrap_or("Resource");
+    let resource_id = resource.map(|r| r.id.as_str()).unwrap_or("default");
+
+    entities.push(EntityJson {
+        uid: EntityUid {
+            entity_type: format!("{ns}::{resource_type}"),
+            id: resource_id.to_string(),
+        },
+        attrs: BTreeMap::new(),
+        parents: Vec::new(),
+    });
+
+    entities
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ResourceConfig;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_entities_with_roles() {
+        let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([
+                ("admin".to_string(), vec!["*".to_string()]),
+                ("analyst".to_string(), vec!["search".to_string()]),
+            ])),
+            ..Default::default()
+        };
+        let entities = generate_entities(&config);
+        assert_eq!(entities.len(), 3);
+
+        let admin = entities.iter().find(|e| e.uid.id == "admin").unwrap();
+        assert_eq!(admin.uid.entity_type, "Agent::Role");
+
+        let analyst = entities.iter().find(|e| e.uid.id == "analyst").unwrap();
+        assert_eq!(analyst.uid.entity_type, "Agent::Role");
+
+        let resource = entities.iter().find(|e| e.uid.id == "default").unwrap();
+        assert_eq!(resource.uid.entity_type, "Agent::Resource");
+    }
+
+    #[test]
+    fn test_entities_default_resource() {
+        let config = CedarAgentConfig::default();
+        let entities = generate_entities(&config);
+        assert_eq!(entities.len(), 1);
+        assert_eq!(entities[0].uid.entity_type, "Agent::Resource");
+        assert_eq!(entities[0].uid.id, "default");
+    }
+
+    #[test]
+    fn test_entities_custom_resource() {
+        let config = CedarAgentConfig {
+            resource: Some(ResourceConfig {
+                resource_type: "ApiGateway".to_string(),
+                id: "prod".to_string(),
+            }),
+            ..Default::default()
+        };
+        let entities = generate_entities(&config);
+        assert_eq!(entities.len(), 1);
+        assert_eq!(entities[0].uid.entity_type, "Agent::ApiGateway");
+        assert_eq!(entities[0].uid.id, "prod");
+    }
+
+    #[test]
+    fn test_entities_with_users() {
+        let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([
+                ("admin".to_string(), vec!["*".to_string()]),
+                ("analyst".to_string(), vec!["search".to_string()]),
+            ])),
+            users: Some(BTreeMap::from([
+                ("alice".to_string(), vec!["admin".to_string()]),
+                ("bob".to_string(), vec!["analyst".to_string()]),
+            ])),
+            ..Default::default()
+        };
+        let entities = generate_entities(&config);
+        // 2 roles + 2 users + 1 resource = 5
+        assert_eq!(entities.len(), 5);
+
+        let alice = entities.iter().find(|e| e.uid.id == "alice").unwrap();
+        assert_eq!(alice.uid.entity_type, "Agent::User");
+        assert_eq!(
+            alice.parents,
+            vec![EntityUid {
+                entity_type: "Agent::Role".to_string(),
+                id: "admin".to_string()
+            }]
+        );
+
+        let bob = entities.iter().find(|e| e.uid.id == "bob").unwrap();
+        assert_eq!(bob.uid.entity_type, "Agent::User");
+        assert_eq!(
+            bob.parents,
+            vec![EntityUid {
+                entity_type: "Agent::Role".to_string(),
+                id: "analyst".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn test_entities_multi_role_user() {
+        let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([
+                ("admin".to_string(), vec!["*".to_string()]),
+                ("developer".to_string(), vec!["deploy".to_string()]),
+            ])),
+            users: Some(BTreeMap::from([(
+                "charlie".to_string(),
+                vec!["admin".to_string(), "developer".to_string()],
+            )])),
+            ..Default::default()
+        };
+        let entities = generate_entities(&config);
+        let charlie = entities.iter().find(|e| e.uid.id == "charlie").unwrap();
+        assert_eq!(charlie.parents.len(), 2);
+        assert!(charlie.parents.contains(&EntityUid {
+            entity_type: "Agent::Role".to_string(),
+            id: "admin".to_string()
+        }));
+        assert!(charlie.parents.contains(&EntityUid {
+            entity_type: "Agent::Role".to_string(),
+            id: "developer".to_string()
+        }));
+    }
+}

--- a/rust/cedar-policy-agent-builder/src/entities.rs
+++ b/rust/cedar-policy-agent-builder/src/entities.rs
@@ -1,21 +1,33 @@
+//! Entity generation for the Cedar authorizer.
+//!
+//! Produces the entity hierarchy (users, roles, resource) in Cedar's JSON entity format.
+
 use crate::config::CedarAgentConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// A Cedar entity UID in the JSON entity format (`{"type": "...", "id": "..."}`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EntityUid {
+    /// Fully qualified entity type (e.g. `"Agent::User"`).
     #[serde(rename = "type")]
     pub entity_type: String,
+    /// Entity identifier (e.g. `"alice"`).
     pub id: String,
 }
 
+/// A Cedar entity in JSON format, suitable for passing to `Entities::from_json_str`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EntityJson {
+    /// The entity's unique identifier.
     pub uid: EntityUid,
+    /// Entity attributes (currently unused, reserved for future extensions).
     pub attrs: BTreeMap<String, serde_json::Value>,
+    /// Parent entities this entity belongs to (e.g. a user's roles).
     pub parents: Vec<EntityUid>,
 }
 
+/// Generate the entity hierarchy from configuration.
 pub fn generate_entities(config: &CedarAgentConfig) -> Vec<EntityJson> {
     let mut entities = Vec::new();
     let ns = &config.namespace;

--- a/rust/cedar-policy-agent-builder/src/lib.rs
+++ b/rust/cedar-policy-agent-builder/src/lib.rs
@@ -349,26 +349,16 @@ fn generate_schema(config: &CedarAgentConfig) -> Result<Option<String>, SchemaEr
 
     let server_json = serde_json::json!({ "result": { "tools": tools_json } });
 
-    use cedar_policy_core::extensions::Extensions;
-    use cedar_policy_core::validator::json_schema::Fragment;
-    use cedar_policy_core::validator::RawName;
     use cedar_policy_mcp_schema_generator::{SchemaGenerator, SchemaGeneratorConfig};
     use mcp_tools_sdk::description::ServerDescription;
 
-    let fragment: Fragment<RawName> =
-        Fragment::from_cedarschema_str(&schema_stub, Extensions::all_available())
-            .map(|(f, _)| f)
-            .map_err(|e| SchemaError {
-                stage: "parse_schema_stub".to_string(),
-                message: format!("{e}"),
-            })?;
-
     let schema_config = SchemaGeneratorConfig::default();
     let mut generator =
-        SchemaGenerator::new_with_config(fragment, schema_config).map_err(|e| SchemaError {
-            stage: "init_generator".to_string(),
-            message: format!("{e}"),
-        })?;
+        SchemaGenerator::from_cedarschema_str_with_config(&schema_stub, schema_config)
+            .map_err(|e| SchemaError {
+                stage: "init_generator".to_string(),
+                message: format!("{e}"),
+            })?;
 
     let server_str = server_json.to_string();
     let server_desc = ServerDescription::from_json_str(&server_str).map_err(|e| SchemaError {

--- a/rust/cedar-policy-agent-builder/src/lib.rs
+++ b/rust/cedar-policy-agent-builder/src/lib.rs
@@ -1,0 +1,394 @@
+pub mod builder;
+pub mod config;
+pub mod entities;
+pub mod policy;
+
+pub use builder::{BuilderError, CedarAgentPolicyBuilder};
+
+use cedar_policy::{PolicySet, Schema, ValidationMode, Validator};
+use config::CedarAgentConfig;
+use entities::{generate_entities, EntityJson};
+use policy::generate_policies;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationError {
+    pub policy_id: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationResult {
+    pub valid: bool,
+    pub errors: Vec<ValidationError>,
+    pub warnings: Vec<ValidationError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildResult {
+    pub policies: String,
+    pub entities: Vec<EntityJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub schema_errors: Vec<SchemaError>,
+}
+
+impl BuildResult {
+    pub fn validate(&self) -> ValidationResult {
+        let schema_str = match &self.schema {
+            Some(s) => s,
+            None => {
+                return ValidationResult {
+                    valid: true,
+                    errors: Vec::new(),
+                    warnings: Vec::new(),
+                }
+            }
+        };
+
+        let schema: Schema = match schema_str.parse() {
+            Ok(s) => s,
+            Err(e) => {
+                return ValidationResult {
+                    valid: false,
+                    errors: vec![ValidationError {
+                        policy_id: String::new(),
+                        message: format!("schema parse error: {e}"),
+                        help: None,
+                    }],
+                    warnings: Vec::new(),
+                };
+            }
+        };
+
+        let policy_set: PolicySet = match self.policies.parse() {
+            Ok(p) => p,
+            Err(e) => {
+                return ValidationResult {
+                    valid: false,
+                    errors: vec![ValidationError {
+                        policy_id: String::new(),
+                        message: format!("policy parse error: {e}"),
+                        help: None,
+                    }],
+                    warnings: Vec::new(),
+                };
+            }
+        };
+
+        let validator = Validator::new(schema);
+        let result = validator.validate(&policy_set, ValidationMode::default());
+
+        let errors: Vec<ValidationError> = result
+            .validation_errors()
+            .map(|e| ValidationError {
+                policy_id: e.policy_id().to_string(),
+                message: e.to_string(),
+                help: None,
+            })
+            .collect();
+
+        let warnings: Vec<ValidationError> = result
+            .validation_warnings()
+            .map(|w| ValidationError {
+                policy_id: w.policy_id().to_string(),
+                message: w.to_string(),
+                help: None,
+            })
+            .collect();
+
+        ValidationResult {
+            valid: errors.is_empty(),
+            errors,
+            warnings,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaError {
+    pub stage: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "schema generation failed at {}: {}",
+            self.stage, self.message
+        )
+    }
+}
+
+pub fn build(config: &CedarAgentConfig) -> BuildResult {
+    let policies = generate_policies(config);
+    let entities = generate_entities(config);
+    let (schema, schema_errors) = match generate_schema(config) {
+        Ok(s) => (s, Vec::new()),
+        Err(e) => (None, vec![e]),
+    };
+
+    BuildResult {
+        policies,
+        entities,
+        schema,
+        schema_errors,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::McpToolDefinition;
+
+    #[test]
+    fn test_build_with_tools_generates_schema() {
+        let config = CedarAgentConfig {
+            roles: Some(std::collections::BTreeMap::from([(
+                "admin".to_string(),
+                vec!["*".to_string()],
+            )])),
+            tools: Some(vec![McpToolDefinition {
+                name: "search".to_string(),
+                description: Some("Search for items".to_string()),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "query": { "type": "string" }
+                    }
+                }),
+                output_schema: None,
+            }]),
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(result.schema.is_some());
+        assert!(result.schema_errors.is_empty());
+        let schema = result.schema.unwrap();
+        assert!(schema.contains("search"));
+    }
+
+    #[test]
+    fn test_build_without_tools_has_no_schema() {
+        let config = CedarAgentConfig {
+            roles: Some(std::collections::BTreeMap::from([(
+                "admin".to_string(),
+                vec!["*".to_string()],
+            )])),
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(result.schema.is_none());
+        assert!(result.schema_errors.is_empty());
+    }
+
+    #[test]
+    fn test_schema_errors_surfaced_in_result() {
+        let config = CedarAgentConfig {
+            tools: Some(vec![McpToolDefinition {
+                name: "".to_string(),
+                description: None,
+                input_schema: serde_json::json!(null),
+                output_schema: None,
+            }]),
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(!result.schema_errors.is_empty());
+        assert!(result.schema.is_none());
+        assert!(!result.schema_errors[0].message.is_empty());
+    }
+
+    #[test]
+    fn test_build_with_output_schema() {
+        let config = CedarAgentConfig {
+            tools: Some(vec![McpToolDefinition {
+                name: "fetch".to_string(),
+                description: Some("Fetch data".to_string()),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": { "url": { "type": "string" } }
+                }),
+                output_schema: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": { "body": { "type": "string" } }
+                })),
+            }]),
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(result.schema.is_some());
+        assert!(result.schema_errors.is_empty());
+    }
+
+    #[test]
+    fn test_validate_no_schema_returns_valid() {
+        let result = BuildResult {
+            policies: String::new(),
+            entities: Vec::new(),
+            schema: None,
+            schema_errors: Vec::new(),
+        };
+        let validation = result.validate();
+        assert!(validation.valid);
+        assert!(validation.errors.is_empty());
+    }
+
+    #[test]
+    fn test_validate_invalid_policy_returns_error() {
+        let result = BuildResult {
+            policies: "this is not valid cedar".to_string(),
+            entities: Vec::new(),
+            schema: Some("namespace Agent { entity User; }".to_string()),
+            schema_errors: Vec::new(),
+        };
+        let validation = result.validate();
+        assert!(!validation.valid);
+        assert!(!validation.errors.is_empty());
+        assert!(validation.errors[0].message.contains("policy parse error"));
+    }
+
+    #[test]
+    fn test_validate_invalid_schema_returns_error() {
+        let result = BuildResult {
+            policies: "permit(principal, action, resource);".to_string(),
+            entities: Vec::new(),
+            schema: Some("not valid schema syntax {{{{".to_string()),
+            schema_errors: Vec::new(),
+        };
+        let validation = result.validate();
+        assert!(!validation.valid);
+        assert!(!validation.errors.is_empty());
+        assert!(validation.errors[0].message.contains("schema parse error"));
+    }
+
+    #[test]
+    fn test_build_with_custom_resource() {
+        let config = CedarAgentConfig {
+            resource: Some(config::ResourceConfig {
+                resource_type: "Gateway".to_string(),
+                id: "prod".to_string(),
+            }),
+            tools: Some(vec![McpToolDefinition {
+                name: "invoke".to_string(),
+                description: None,
+                input_schema: serde_json::json!({"type": "object"}),
+                output_schema: None,
+            }]),
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(result.schema.is_some());
+        assert!(result.schema_errors.is_empty());
+        let schema = result.schema.unwrap();
+        assert!(schema.contains("Gateway"));
+    }
+
+    #[test]
+    fn test_build_empty_tools_vec_no_schema() {
+        let config = CedarAgentConfig {
+            tools: Some(vec![]),
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(result.schema.is_none());
+        assert!(result.schema_errors.is_empty());
+    }
+
+    #[test]
+    fn test_schema_error_display() {
+        let err = SchemaError {
+            stage: "test_stage".to_string(),
+            message: "something broke".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "schema generation failed at test_stage: something broke"
+        );
+    }
+}
+
+fn generate_schema(config: &CedarAgentConfig) -> Result<Option<String>, SchemaError> {
+    let tools = match config.tools.as_ref() {
+        Some(t) if !t.is_empty() => t,
+        _ => return Ok(None),
+    };
+
+    let principal_type = &config.principal.principal_type;
+    let resource_type = config
+        .resource
+        .as_ref()
+        .map(|r| r.resource_type.as_str())
+        .unwrap_or("Resource");
+    let ns = &config.namespace;
+
+    let schema_stub = format!(
+        "namespace {ns} {{\n  entity Role;\n\n  @mcp_principal(\"{principal_type}\")\n  entity {principal_type} in [Role];\n\n  @mcp_resource(\"{resource_type}\")\n  entity {resource_type};\n}}"
+    );
+
+    let tools_json: Vec<serde_json::Value> = tools
+        .iter()
+        .map(|t| {
+            let mut obj = serde_json::json!({
+                "name": t.name,
+                "description": t.description.as_deref().unwrap_or(""),
+                "inputSchema": t.input_schema,
+            });
+            if let Some(output) = &t.output_schema {
+                if let Some(o) = obj.as_object_mut() {
+                    o.insert("outputSchema".to_string(), output.clone());
+                }
+            }
+            obj
+        })
+        .collect();
+
+    let server_json = serde_json::json!({ "result": { "tools": tools_json } });
+
+    use cedar_policy_core::extensions::Extensions;
+    use cedar_policy_core::validator::json_schema::Fragment;
+    use cedar_policy_core::validator::RawName;
+    use cedar_policy_mcp_schema_generator::{SchemaGenerator, SchemaGeneratorConfig};
+    use mcp_tools_sdk::description::ServerDescription;
+
+    let fragment: Fragment<RawName> =
+        Fragment::from_cedarschema_str(&schema_stub, Extensions::all_available())
+            .map(|(f, _)| f)
+            .map_err(|e| SchemaError {
+                stage: "parse_schema_stub".to_string(),
+                message: format!("{e}"),
+            })?;
+
+    let schema_config = SchemaGeneratorConfig::default();
+    let mut generator =
+        SchemaGenerator::new_with_config(fragment, schema_config).map_err(|e| SchemaError {
+            stage: "init_generator".to_string(),
+            message: format!("{e}"),
+        })?;
+
+    let server_str = server_json.to_string();
+    let server_desc = ServerDescription::from_json_str(&server_str).map_err(|e| SchemaError {
+        stage: "parse_server_description".to_string(),
+        message: format!("{e}"),
+    })?;
+
+    generator
+        .add_actions_from_server_description(&server_desc)
+        .map_err(|e| SchemaError {
+            stage: "add_actions".to_string(),
+            message: format!("{e}"),
+        })?;
+
+    let schema_fragment = generator.get_schema();
+    schema_fragment
+        .to_cedarschema()
+        .map(Some)
+        .map_err(|e| SchemaError {
+            stage: "serialize_schema".to_string(),
+            message: format!("{e}"),
+        })
+}

--- a/rust/cedar-policy-agent-builder/src/lib.rs
+++ b/rust/cedar-policy-agent-builder/src/lib.rs
@@ -1,3 +1,56 @@
+//! Generate [Cedar](https://www.cedarpolicy.com/) policies, entities, and schemas
+//! from a declarative agent authorization configuration.
+//!
+//! This crate provides [`CedarAgentPolicyBuilder`], a fluent builder that produces
+//! valid Cedar policy text, entity JSON, and (optionally) a Cedar schema from a
+//! high-level description of roles, users, rate limits, time windows, and other
+//! authorization constraints for AI agent tool access.
+//!
+//! # Quick start
+//!
+//! ```rust
+//! use cedar_policy_agent_builder::CedarAgentPolicyBuilder;
+//!
+//! let result = CedarAgentPolicyBuilder::new()
+//!     .namespace("MyApp").unwrap()
+//!     .principal("sub", "User").unwrap()
+//!     .role("admin", &["*"])
+//!     .role("analyst", &["search", "query"])
+//!     .user("alice", &["admin"])
+//!     .user("bob", &["analyst"])
+//!     .rate_limit("send_email", 5)
+//!     .time_window("*", (9, 17)).unwrap()
+//!     .deny_in_env("production", &["delete"])
+//!     .build();
+//!
+//! // `result.policies` is valid Cedar policy text
+//! // `result.entities` is the entity hierarchy (serialize to JSON for the authorizer)
+//! // `result.schema` is an optional Cedar schema (present when tool definitions are provided)
+//! ```
+//!
+//! # Entity model
+//!
+//! The builder produces an entity hierarchy where users are members of roles:
+//!
+//! ```text
+//! Namespace::User::"alice" in [Namespace::Role::"admin"]
+//! Namespace::Role::"admin"
+//! Namespace::Resource::"default"
+//! ```
+//!
+//! Policies use `principal in Role::"name"` to grant access based on role membership.
+//!
+//! # Policy types
+//!
+//! The builder generates the following Cedar policy patterns:
+//!
+//! - **Role permits** — `permit` policies scoped to a role and optionally to specific actions
+//! - **Rate limits** — `forbid` policies that deny when a session call counter exceeds a threshold
+//! - **Time windows** — `forbid` policies that deny outside allowed UTC hours
+//! - **Environment denials** — `forbid` policies that deny specific tools in named environments
+//! - **Consent gates** — `permit` policies that require explicit user consent before execution
+//! - **Input restrictions** — `forbid` policies that deny unless input fields match allowed values
+
 pub mod builder;
 pub mod config;
 pub mod entities;
@@ -11,32 +64,54 @@ use entities::{generate_entities, EntityJson};
 use policy::generate_policies;
 use serde::{Deserialize, Serialize};
 
+/// A single validation error or warning from Cedar's policy validator.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationError {
+    /// The policy ID that triggered this error, or empty for schema-level errors.
     pub policy_id: String,
+    /// Human-readable description of the validation issue.
     pub message: String,
+    /// Optional suggestion for how to fix the issue.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help: Option<String>,
 }
 
+/// Result of validating generated policies against a schema.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationResult {
+    /// Whether all policies passed validation.
     pub valid: bool,
+    /// Validation errors (policies that violate the schema).
     pub errors: Vec<ValidationError>,
+    /// Validation warnings (policies that are valid but potentially problematic).
     pub warnings: Vec<ValidationError>,
 }
 
+/// The output of [`CedarAgentPolicyBuilder::build`] or [`build`].
+///
+/// Contains everything needed to configure a Cedar authorizer for agent tool access.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BuildResult {
+    /// Cedar policy text (one or more `permit`/`forbid` statements).
+    /// Parse with `policies.parse::<cedar_policy::PolicySet>()`.
     pub policies: String,
+    /// Entity hierarchy in Cedar's JSON entity format.
+    /// Includes roles, users with role membership, and the resource entity.
     pub entities: Vec<EntityJson>,
+    /// Cedar schema in `.cedarschema` format, if tool definitions were provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<String>,
+    /// Errors encountered during schema generation (non-fatal — policies and entities
+    /// are still produced).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub schema_errors: Vec<SchemaError>,
 }
 
 impl BuildResult {
+    /// Validate the generated policies against the schema (if present).
+    ///
+    /// Returns [`ValidationResult::valid`] = `true` if no schema was generated
+    /// (nothing to validate against) or if all policies pass Cedar's validator.
     pub fn validate(&self) -> ValidationResult {
         let schema_str = match &self.schema {
             Some(s) => s,
@@ -108,9 +183,12 @@ impl BuildResult {
     }
 }
 
+/// An error that occurred during Cedar schema generation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SchemaError {
+    /// The generation stage where the error occurred (e.g. "init_generator", "add_actions").
     pub stage: String,
+    /// Human-readable error message.
     pub message: String,
 }
 
@@ -124,6 +202,10 @@ impl std::fmt::Display for SchemaError {
     }
 }
 
+/// Build Cedar policies, entities, and schema from a configuration struct.
+///
+/// Prefer [`CedarAgentPolicyBuilder`] for a fluent API. This function is the
+/// lower-level entry point used internally by the builder.
 pub fn build(config: &CedarAgentConfig) -> BuildResult {
     let policies = generate_policies(config);
     let entities = generate_entities(config);
@@ -354,11 +436,12 @@ fn generate_schema(config: &CedarAgentConfig) -> Result<Option<String>, SchemaEr
 
     let schema_config = SchemaGeneratorConfig::default();
     let mut generator =
-        SchemaGenerator::from_cedarschema_str_with_config(&schema_stub, schema_config)
-            .map_err(|e| SchemaError {
+        SchemaGenerator::from_cedarschema_str_with_config(&schema_stub, schema_config).map_err(
+            |e| SchemaError {
                 stage: "init_generator".to_string(),
                 message: format!("{e}"),
-            })?;
+            },
+        )?;
 
     let server_str = server_json.to_string();
     let server_desc = ServerDescription::from_json_str(&server_str).map_err(|e| SchemaError {

--- a/rust/cedar-policy-agent-builder/src/policy.rs
+++ b/rust/cedar-policy-agent-builder/src/policy.rs
@@ -1,12 +1,10 @@
 use crate::config::{CedarAgentConfig, ConsentScope};
+use cedar_policy::EntityId;
 use std::collections::BTreeSet;
 
-fn escape_cedar_string(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
 fn action_ref(ns: &str, name: &str) -> String {
-    format!("action == {ns}::Action::\"{}\"", escape_cedar_string(name))
+    let eid = EntityId::new(name);
+    format!("action == {ns}::Action::\"{}\"", eid.escaped())
 }
 
 // Tools like "my-tool" and "my_tool" will collide to the same counter key.
@@ -47,7 +45,7 @@ fn generate_role_policies(config: &CedarAgentConfig) -> Vec<String> {
 
     for (role_name, tools) in roles {
         let consent_tools = get_consent_tools_for_role(config, role_name);
-        let role_ref = format!("{ns}::Role::\"{}\"", escape_cedar_string(role_name));
+        let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role_name).escaped());
 
         if tools.contains(&"*".to_string()) {
             if consent_tools.is_empty() {
@@ -100,12 +98,15 @@ fn generate_restriction_policies(config: &CedarAgentConfig) -> Vec<String> {
                 .iter()
                 .map(|v| {
                     let formatted = format_cedar_value(v);
-                    format!("context.input.{field} == {formatted}")
+                    format!(
+                        "context.input[\"{}\"] == {formatted}",
+                        EntityId::new(field).escaped()
+                    )
                 })
                 .collect();
             policies.push(format!(
                 "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{\n  !(context.input has \"{}\" && ({}))\n}};",
-                escape_cedar_string(field),
+                EntityId::new(field).escaped(),
                 value_checks.join(" || ")
             ));
         }
@@ -176,14 +177,14 @@ fn generate_env_denial_policies(config: &CedarAgentConfig) -> Vec<String> {
         if tools.contains(&"*".to_string()) {
             policies.push(format!(
                 "forbid(\n  principal,\n  action,\n  resource\n) when {{ context.session has \"environment\" && context.session.environment == \"{}\" }};",
-                escape_cedar_string(env)
+                EntityId::new(env).escaped()
             ));
         } else {
             for tool in tools {
                 policies.push(format!(
                     "forbid(\n  principal,\n  {},\n  resource\n) when {{ context.session has \"environment\" && context.session.environment == \"{}\" }};",
                     action_ref(ns, tool),
-                    escape_cedar_string(env)
+                    EntityId::new(env).escaped()
                 ));
             }
         }
@@ -209,7 +210,7 @@ fn generate_consent_policies(config: &CedarAgentConfig) -> Vec<String> {
             ));
         } else {
             for role in &roles {
-                let role_ref = format!("{ns}::Role::\"{}\"", escape_cedar_string(role));
+                let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role).escaped());
                 policies.push(format!(
                     "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent == true }};",
                 ));
@@ -222,10 +223,10 @@ fn generate_consent_policies(config: &CedarAgentConfig) -> Vec<String> {
 
 fn format_cedar_value(v: &serde_json::Value) -> String {
     match v {
-        serde_json::Value::String(s) => format!("\"{}\"", escape_cedar_string(s)),
+        serde_json::Value::String(s) => format!("\"{}\"", EntityId::new(s).escaped()),
         serde_json::Value::Number(n) => n.to_string(),
         serde_json::Value::Bool(b) => b.to_string(),
-        _ => format!("\"{}\"", escape_cedar_string(&v.to_string())),
+        _ => format!("\"{}\"", EntityId::new(v.to_string()).escaped()),
     }
 }
 
@@ -244,16 +245,15 @@ pub fn generate_policies(config: &CedarAgentConfig) -> String {
 mod tests {
     use super::*;
     use crate::config::{PrincipalConfig, Restriction};
+    use cedar_policy::PolicySet;
     use std::collections::BTreeMap;
 
-    #[test]
-    fn test_escape_cedar_string() {
-        assert_eq!(
-            escape_cedar_string("hello \"world\""),
-            "hello \\\"world\\\""
-        );
-        assert_eq!(escape_cedar_string("back\\slash"), "back\\\\slash");
-        assert_eq!(escape_cedar_string("admin"), "admin");
+    fn assert_valid_cedar(policies: &str) {
+        if !policies.is_empty() {
+            policies.parse::<PolicySet>().unwrap_or_else(|e| {
+                panic!("generated policies are not valid Cedar:\n{policies}\nerror: {e}")
+            });
+        }
     }
 
     #[test]
@@ -270,6 +270,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "permit(principal in Agent::Role::\"analyst\", action == Agent::Action::\"search\", resource);"
         ));
@@ -288,6 +289,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains("permit(principal in Agent::Role::\"admin\", action, resource);"));
     }
 
@@ -309,8 +311,9 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
-            "forbid(\n  principal,\n  action == Agent::Action::\"query_database\",\n  resource\n) when {\n  !(context.input has \"database\" && (context.input.database == \"analytics\" || context.input.database == \"reporting\"))\n};"
+            "forbid(\n  principal,\n  action == Agent::Action::\"query_database\",\n  resource\n) when {\n  !(context.input has \"database\" && (context.input[\"database\"] == \"analytics\" || context.input[\"database\"] == \"reporting\"))\n};"
         ));
     }
 
@@ -321,6 +324,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "forbid(\n  principal,\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"call_count_send_email\" && context.session.call_count_send_email >= 3 };"
         ));
@@ -333,6 +337,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "forbid(\n  principal,\n  action,\n  resource\n) when { context.session has \"call_count\" && context.session.call_count >= 100 };"
         ));
@@ -351,6 +356,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "forbid(\n  principal,\n  action,\n  resource\n) when { context.session has \"hour_utc\" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };"
         ));
@@ -369,6 +375,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "forbid(\n  principal,\n  action == Agent::Action::\"deploy\",\n  resource\n) when { context.session has \"hour_utc\" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };"
         ));
@@ -384,6 +391,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "forbid(\n  principal,\n  action == Agent::Action::\"delete_record\",\n  resource\n) when { context.session has \"environment\" && context.session.environment == \"production\" };"
         ));
@@ -399,6 +407,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "permit(\n  principal,\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
         ));
@@ -414,6 +423,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
         ));
@@ -433,6 +443,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         // send_email should NOT appear in the role permit
         assert!(!policies.contains(
             "principal in Agent::Role::\"analyst\", action == Agent::Action::\"send_email\", resource);"
@@ -457,6 +468,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains("!(action == Agent::Action::\"send_email\")"));
     }
 
@@ -487,6 +499,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains("Agent::Action::\"tool\\\"inject\""));
         assert!(policies.contains("Agent::Role::\"role\\\"evil\""));
     }
@@ -506,6 +519,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains("call_count_my_tool_v2"));
         assert!(!policies.contains("call_count_my.tool-v2"));
     }
@@ -531,6 +545,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains(
             "forbid(\n  principal,\n  action == Agent::Action::\"dangerous_tool\",\n  resource\n);"
         ));
@@ -546,6 +561,7 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
+        assert_valid_cedar(&policies);
         assert!(policies.contains("action,"));
         assert!(policies.contains("\"staging\""));
     }
@@ -578,7 +594,8 @@ mod tests {
             ..Default::default()
         };
         let policies = generate_policies(&config);
-        assert!(policies.contains("context.input.limit == 100"));
-        assert!(policies.contains("context.input.limit == 500"));
+        assert_valid_cedar(&policies);
+        assert!(policies.contains("context.input[\"limit\"] == 100"));
+        assert!(policies.contains("context.input[\"limit\"] == 500"));
     }
 }

--- a/rust/cedar-policy-agent-builder/src/policy.rs
+++ b/rust/cedar-policy-agent-builder/src/policy.rs
@@ -1,0 +1,584 @@
+use crate::config::{CedarAgentConfig, ConsentScope};
+use std::collections::BTreeSet;
+
+fn escape_cedar_string(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn action_ref(ns: &str, name: &str) -> String {
+    format!("action == {ns}::Action::\"{}\"", escape_cedar_string(name))
+}
+
+// Tools like "my-tool" and "my_tool" will collide to the same counter key.
+fn sanitize_counter_key(tool: &str) -> String {
+    tool.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+fn normalize_consent_roles(scope: &ConsentScope) -> Vec<&str> {
+    match scope {
+        ConsentScope::AllRoles(true) => vec!["*"],
+        ConsentScope::AllRoles(false) => vec![],
+        ConsentScope::SpecificRoles(roles) => roles.iter().map(|s| s.as_str()).collect(),
+    }
+}
+
+fn get_consent_tools_for_role(config: &CedarAgentConfig, role_name: &str) -> BTreeSet<String> {
+    let mut tools = BTreeSet::new();
+    if let Some(consent) = &config.consent {
+        for (tool, scope) in consent {
+            let roles = normalize_consent_roles(scope);
+            if roles.contains(&"*") || roles.contains(&role_name) {
+                tools.insert(tool.clone());
+            }
+        }
+    }
+    tools
+}
+
+fn generate_role_policies(config: &CedarAgentConfig) -> Vec<String> {
+    let roles = match &config.roles {
+        Some(r) => r,
+        None => return Vec::new(),
+    };
+    let ns = &config.namespace;
+    let mut policies = Vec::new();
+
+    for (role_name, tools) in roles {
+        let consent_tools = get_consent_tools_for_role(config, role_name);
+        let role_ref = format!("{ns}::Role::\"{}\"", escape_cedar_string(role_name));
+
+        if tools.contains(&"*".to_string()) {
+            if consent_tools.is_empty() {
+                policies.push(format!(
+                    "permit(principal in {role_ref}, action, resource);"
+                ));
+            } else {
+                let exclusions: Vec<String> =
+                    consent_tools.iter().map(|t| action_ref(ns, t)).collect();
+                policies.push(format!(
+                    "permit(\n  principal in {role_ref},\n  action,\n  resource\n) when {{ !({}) }};",
+                    exclusions.join(" || ")
+                ));
+            }
+        } else {
+            let filtered: Vec<&String> = tools
+                .iter()
+                .filter(|t| !consent_tools.contains(t.as_str()))
+                .collect();
+            for tool in filtered {
+                policies.push(format!(
+                    "permit(principal in {role_ref}, {}, resource);",
+                    action_ref(ns, tool)
+                ));
+            }
+        }
+    }
+
+    policies
+}
+
+fn generate_restriction_policies(config: &CedarAgentConfig) -> Vec<String> {
+    let restrictions = match &config.restrictions {
+        Some(r) => r,
+        None => return Vec::new(),
+    };
+    let ns = &config.namespace;
+    let mut policies = Vec::new();
+
+    for (tool, restriction) in restrictions {
+        let action_clause = action_ref(ns, tool);
+        if restriction.allowed_values.is_empty() {
+            policies.push(format!(
+                "forbid(\n  principal,\n  {action_clause},\n  resource\n);"
+            ));
+            continue;
+        }
+        for (field, allowed_values) in &restriction.allowed_values {
+            let value_checks: Vec<String> = allowed_values
+                .iter()
+                .map(|v| {
+                    let formatted = format_cedar_value(v);
+                    format!("context.input.{field} == {formatted}")
+                })
+                .collect();
+            policies.push(format!(
+                "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{\n  !(context.input has \"{}\" && ({}))\n}};",
+                escape_cedar_string(field),
+                value_checks.join(" || ")
+            ));
+        }
+    }
+
+    policies
+}
+
+fn generate_rate_limit_policies(config: &CedarAgentConfig) -> Vec<String> {
+    let rate_limits = match &config.rate_limits {
+        Some(r) => r,
+        None => return Vec::new(),
+    };
+    let ns = &config.namespace;
+    let mut policies = Vec::new();
+
+    for (tool, max) in rate_limits {
+        if tool == "*" {
+            policies.push(format!(
+                "forbid(\n  principal,\n  action,\n  resource\n) when {{ context.session has \"call_count\" && context.session.call_count >= {max} }};",
+            ));
+        } else {
+            let action_clause = action_ref(ns, tool);
+            let counter_key = format!("call_count_{}", sanitize_counter_key(tool));
+            policies.push(format!(
+                "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{ context.session has \"{}\" && context.session.{} >= {max} }};",
+                counter_key,
+                counter_key
+            ));
+        }
+    }
+
+    policies
+}
+
+fn generate_time_window_policies(config: &CedarAgentConfig) -> Vec<String> {
+    let time_windows = match &config.time_windows {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    let ns = &config.namespace;
+    let mut policies = Vec::new();
+
+    for (tool, tw) in time_windows {
+        let action_clause = if tool == "*" {
+            "action".to_string()
+        } else {
+            action_ref(ns, tool)
+        };
+        policies.push(format!(
+            "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{ context.session has \"hour_utc\" && (context.session.hour_utc < {} || context.session.hour_utc >= {}) }};",
+            tw.hour_start, tw.hour_end
+        ));
+    }
+
+    policies
+}
+
+fn generate_env_denial_policies(config: &CedarAgentConfig) -> Vec<String> {
+    let deny_in_env = match &config.deny_in_env {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+    let ns = &config.namespace;
+    let mut policies = Vec::new();
+
+    for (env, tools) in deny_in_env {
+        if tools.contains(&"*".to_string()) {
+            policies.push(format!(
+                "forbid(\n  principal,\n  action,\n  resource\n) when {{ context.session has \"environment\" && context.session.environment == \"{}\" }};",
+                escape_cedar_string(env)
+            ));
+        } else {
+            for tool in tools {
+                policies.push(format!(
+                    "forbid(\n  principal,\n  {},\n  resource\n) when {{ context.session has \"environment\" && context.session.environment == \"{}\" }};",
+                    action_ref(ns, tool),
+                    escape_cedar_string(env)
+                ));
+            }
+        }
+    }
+
+    policies
+}
+
+fn generate_consent_policies(config: &CedarAgentConfig) -> Vec<String> {
+    let consent = match &config.consent {
+        Some(c) => c,
+        None => return Vec::new(),
+    };
+    let ns = &config.namespace;
+    let mut policies = Vec::new();
+
+    for (tool, scope) in consent {
+        let action_clause = action_ref(ns, tool);
+        let roles = normalize_consent_roles(scope);
+        if roles.contains(&"*") {
+            policies.push(format!(
+                "permit(\n  principal,\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent == true }};",
+            ));
+        } else {
+            for role in &roles {
+                let role_ref = format!("{ns}::Role::\"{}\"", escape_cedar_string(role));
+                policies.push(format!(
+                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent == true }};",
+                ));
+            }
+        }
+    }
+
+    policies
+}
+
+fn format_cedar_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => format!("\"{}\"", escape_cedar_string(s)),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        _ => format!("\"{}\"", escape_cedar_string(&v.to_string())),
+    }
+}
+
+pub fn generate_policies(config: &CedarAgentConfig) -> String {
+    let mut all: Vec<String> = Vec::new();
+    all.extend(generate_role_policies(config));
+    all.extend(generate_restriction_policies(config));
+    all.extend(generate_rate_limit_policies(config));
+    all.extend(generate_time_window_policies(config));
+    all.extend(generate_env_denial_policies(config));
+    all.extend(generate_consent_policies(config));
+    all.join("\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{PrincipalConfig, Restriction};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_escape_cedar_string() {
+        assert_eq!(
+            escape_cedar_string("hello \"world\""),
+            "hello \\\"world\\\""
+        );
+        assert_eq!(escape_cedar_string("back\\slash"), "back\\\\slash");
+        assert_eq!(escape_cedar_string("admin"), "admin");
+    }
+
+    #[test]
+    fn test_role_specific_tools() {
+        let config = CedarAgentConfig {
+            principal: PrincipalConfig {
+                key: "user_id".to_string(),
+                principal_type: "User".to_string(),
+            },
+            roles: Some(BTreeMap::from([(
+                "analyst".to_string(),
+                vec!["search".to_string(), "query_database".to_string()],
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "permit(principal in Agent::Role::\"analyst\", action == Agent::Action::\"search\", resource);"
+        ));
+        assert!(policies.contains(
+            "permit(principal in Agent::Role::\"analyst\", action == Agent::Action::\"query_database\", resource);"
+        ));
+    }
+
+    #[test]
+    fn test_wildcard_role() {
+        let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([(
+                "admin".to_string(),
+                vec!["*".to_string()],
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains("permit(principal in Agent::Role::\"admin\", action, resource);"));
+    }
+
+    #[test]
+    fn test_restriction_policy() {
+        let config = CedarAgentConfig {
+            restrictions: Some(BTreeMap::from([(
+                "query_database".to_string(),
+                Restriction {
+                    allowed_values: BTreeMap::from([(
+                        "database".to_string(),
+                        vec![
+                            serde_json::Value::String("analytics".to_string()),
+                            serde_json::Value::String("reporting".to_string()),
+                        ],
+                    )]),
+                },
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "forbid(\n  principal,\n  action == Agent::Action::\"query_database\",\n  resource\n) when {\n  !(context.input has \"database\" && (context.input.database == \"analytics\" || context.input.database == \"reporting\"))\n};"
+        ));
+    }
+
+    #[test]
+    fn test_rate_limit_per_tool() {
+        let config = CedarAgentConfig {
+            rate_limits: Some(BTreeMap::from([("send_email".to_string(), 3)])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "forbid(\n  principal,\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"call_count_send_email\" && context.session.call_count_send_email >= 3 };"
+        ));
+    }
+
+    #[test]
+    fn test_rate_limit_global() {
+        let config = CedarAgentConfig {
+            rate_limits: Some(BTreeMap::from([("*".to_string(), 100)])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "forbid(\n  principal,\n  action,\n  resource\n) when { context.session has \"call_count\" && context.session.call_count >= 100 };"
+        ));
+    }
+
+    #[test]
+    fn test_time_window_global() {
+        let config = CedarAgentConfig {
+            time_windows: Some(BTreeMap::from([(
+                "*".to_string(),
+                crate::config::TimeWindow {
+                    hour_start: 9,
+                    hour_end: 17,
+                },
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "forbid(\n  principal,\n  action,\n  resource\n) when { context.session has \"hour_utc\" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };"
+        ));
+    }
+
+    #[test]
+    fn test_time_window_tool_scoped() {
+        let config = CedarAgentConfig {
+            time_windows: Some(BTreeMap::from([(
+                "deploy".to_string(),
+                crate::config::TimeWindow {
+                    hour_start: 9,
+                    hour_end: 17,
+                },
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "forbid(\n  principal,\n  action == Agent::Action::\"deploy\",\n  resource\n) when { context.session has \"hour_utc\" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };"
+        ));
+    }
+
+    #[test]
+    fn test_env_denial_policy() {
+        let config = CedarAgentConfig {
+            deny_in_env: Some(BTreeMap::from([(
+                "production".to_string(),
+                vec!["delete_record".to_string()],
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "forbid(\n  principal,\n  action == Agent::Action::\"delete_record\",\n  resource\n) when { context.session has \"environment\" && context.session.environment == \"production\" };"
+        ));
+    }
+
+    #[test]
+    fn test_consent_all_roles() {
+        let config = CedarAgentConfig {
+            consent: Some(BTreeMap::from([(
+                "send_email".to_string(),
+                ConsentScope::AllRoles(true),
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "permit(\n  principal,\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+        ));
+    }
+
+    #[test]
+    fn test_consent_specific_role() {
+        let config = CedarAgentConfig {
+            consent: Some(BTreeMap::from([(
+                "send_email".to_string(),
+                ConsentScope::SpecificRoles(vec!["analyst".to_string()]),
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+        ));
+    }
+
+    #[test]
+    fn test_consent_excludes_from_role_permit() {
+        let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([(
+                "analyst".to_string(),
+                vec!["search".to_string(), "send_email".to_string()],
+            )])),
+            consent: Some(BTreeMap::from([(
+                "send_email".to_string(),
+                ConsentScope::AllRoles(true),
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        // send_email should NOT appear in the role permit
+        assert!(!policies.contains(
+            "principal in Agent::Role::\"analyst\", action == Agent::Action::\"send_email\", resource);"
+        ));
+        // search should still be there
+        assert!(policies.contains(
+            "permit(principal in Agent::Role::\"analyst\", action == Agent::Action::\"search\", resource);"
+        ));
+    }
+
+    #[test]
+    fn test_wildcard_with_consent_exclusion() {
+        let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([(
+                "admin".to_string(),
+                vec!["*".to_string()],
+            )])),
+            consent: Some(BTreeMap::from([(
+                "send_email".to_string(),
+                ConsentScope::AllRoles(true),
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains("!(action == Agent::Action::\"send_email\")"));
+    }
+
+    #[test]
+    fn test_empty_config_produces_no_policies() {
+        let config = CedarAgentConfig::default();
+        let policies = generate_policies(&config);
+        assert!(policies.is_empty());
+    }
+
+    #[test]
+    fn test_empty_role_tools() {
+        let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([("empty".to_string(), vec![])])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.is_empty());
+    }
+
+    #[test]
+    fn test_escapes_special_chars() {
+        let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([(
+                "role\"evil".to_string(),
+                vec!["tool\"inject".to_string()],
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains("Agent::Action::\"tool\\\"inject\""));
+        assert!(policies.contains("Agent::Role::\"role\\\"evil\""));
+    }
+
+    #[test]
+    fn test_sanitize_counter_key() {
+        assert_eq!(sanitize_counter_key("send_email"), "send_email");
+        assert_eq!(sanitize_counter_key("my.tool-v2"), "my_tool_v2");
+        assert_eq!(sanitize_counter_key("ns::action"), "ns__action");
+        assert_eq!(sanitize_counter_key("tool with spaces"), "tool_with_spaces");
+    }
+
+    #[test]
+    fn test_rate_limit_special_chars_in_tool_name() {
+        let config = CedarAgentConfig {
+            rate_limits: Some(BTreeMap::from([("my.tool-v2".to_string(), 10)])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains("call_count_my_tool_v2"));
+        assert!(!policies.contains("call_count_my.tool-v2"));
+    }
+
+    #[test]
+    fn test_format_cedar_value_types() {
+        assert_eq!(format_cedar_value(&serde_json::json!("hello")), "\"hello\"");
+        assert_eq!(format_cedar_value(&serde_json::json!(42)), "42");
+        assert_eq!(format_cedar_value(&serde_json::json!(true)), "true");
+        assert_eq!(format_cedar_value(&serde_json::json!(false)), "false");
+        assert_eq!(format_cedar_value(&serde_json::json!([1, 2])), "\"[1,2]\"");
+    }
+
+    #[test]
+    fn test_restriction_empty_allowed_values() {
+        let config = CedarAgentConfig {
+            restrictions: Some(BTreeMap::from([(
+                "dangerous_tool".to_string(),
+                Restriction {
+                    allowed_values: BTreeMap::new(),
+                },
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains(
+            "forbid(\n  principal,\n  action == Agent::Action::\"dangerous_tool\",\n  resource\n);"
+        ));
+    }
+
+    #[test]
+    fn test_env_denial_wildcard_tools() {
+        let config = CedarAgentConfig {
+            deny_in_env: Some(BTreeMap::from([(
+                "staging".to_string(),
+                vec!["*".to_string()],
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains("action,"));
+        assert!(policies.contains("\"staging\""));
+    }
+
+    #[test]
+    fn test_consent_false_produces_no_policies() {
+        let config = CedarAgentConfig {
+            consent: Some(BTreeMap::from([(
+                "send_email".to_string(),
+                ConsentScope::AllRoles(false),
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.is_empty());
+    }
+
+    #[test]
+    fn test_restriction_with_number_value() {
+        let config = CedarAgentConfig {
+            restrictions: Some(BTreeMap::from([(
+                "query".to_string(),
+                Restriction {
+                    allowed_values: BTreeMap::from([(
+                        "limit".to_string(),
+                        vec![serde_json::json!(100), serde_json::json!(500)],
+                    )]),
+                },
+            )])),
+            ..Default::default()
+        };
+        let policies = generate_policies(&config);
+        assert!(policies.contains("context.input.limit == 100"));
+        assert!(policies.contains("context.input.limit == 500"));
+    }
+}

--- a/rust/cedar-policy-agent-builder/tests/authorization.rs
+++ b/rust/cedar-policy-agent-builder/tests/authorization.rs
@@ -1,0 +1,456 @@
+use cedar_policy::{Authorizer, Context, Entities, EntityUid, PolicySet, Request};
+use cedar_policy_agent_builder::CedarAgentPolicyBuilder;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+
+fn authorize(
+    policies: &str,
+    entities_json: &str,
+    principal: &str,
+    action: &str,
+    resource: &str,
+    context: serde_json::Value,
+) -> cedar_policy::Decision {
+    let policy_set: PolicySet = policies.parse().expect("policies should parse");
+    let entities = Entities::from_json_str(entities_json, None).expect("entities should parse");
+    let principal = EntityUid::from_str(principal).expect("principal should parse");
+    let action = EntityUid::from_str(action).expect("action should parse");
+    let resource = EntityUid::from_str(resource).expect("resource should parse");
+    let context = Context::from_json_value(context, None).expect("context should parse");
+    let request =
+        Request::new(principal, action, resource, context, None).expect("request should build");
+    let authorizer = Authorizer::new();
+    authorizer
+        .is_authorized(&request, &policy_set, &entities)
+        .decision()
+}
+
+fn entities_to_json(entities: &[cedar_policy_agent_builder::entities::EntityJson]) -> String {
+    serde_json::to_string(entities).expect("entities should serialize")
+}
+
+#[test]
+fn test_admin_allowed_any_action() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("admin", &["*"])
+        .user("alice", &["admin"])
+        .build();
+
+    let decision = authorize(
+        &result.policies,
+        &entities_to_json(&result.entities),
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"any_tool\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({}),
+    );
+    assert_eq!(decision, cedar_policy::Decision::Allow);
+}
+
+#[test]
+fn test_unknown_user_denied() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("admin", &["*"])
+        .user("alice", &["admin"])
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+    let entities_with_bob = {
+        let mut ents: Vec<serde_json::Value> = serde_json::from_str(&entities_json).expect("parse");
+        ents.push(serde_json::json!({
+            "uid": {"type": "Agent::User", "id": "bob"},
+            "attrs": {},
+            "parents": []
+        }));
+        serde_json::to_string(&ents).expect("serialize")
+    };
+
+    let decision = authorize(
+        &result.policies,
+        &entities_with_bob,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"search\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({}),
+    );
+    assert_eq!(decision, cedar_policy::Decision::Deny);
+}
+
+#[test]
+fn test_role_scoped_to_specific_tools() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("analyst", &["search", "query"])
+        .user("bob", &["analyst"])
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let allowed = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"search\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({}),
+    );
+    assert_eq!(allowed, cedar_policy::Decision::Allow);
+
+    let denied = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"delete\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({}),
+    );
+    assert_eq!(denied, cedar_policy::Decision::Deny);
+}
+
+#[test]
+fn test_rate_limit_denies_when_exceeded() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("user", &["send_email"])
+        .user("alice", &["user"])
+        .rate_limit("send_email", 5)
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let under_limit = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"send_email\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"call_count_send_email": 3}}),
+    );
+    assert_eq!(under_limit, cedar_policy::Decision::Allow);
+
+    let at_limit = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"send_email\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"call_count_send_email": 5}}),
+    );
+    assert_eq!(at_limit, cedar_policy::Decision::Deny);
+}
+
+#[test]
+fn test_time_window_denies_outside_hours() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("user", &["deploy"])
+        .user("alice", &["user"])
+        .time_window("deploy", (9, 17))
+        .unwrap()
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let within_hours = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"deploy\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 12}}),
+    );
+    assert_eq!(within_hours, cedar_policy::Decision::Allow);
+
+    let outside_hours = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"deploy\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 20}}),
+    );
+    assert_eq!(outside_hours, cedar_policy::Decision::Deny);
+}
+
+#[test]
+fn test_env_denial_blocks_in_production() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("admin", &["*"])
+        .user("alice", &["admin"])
+        .deny_in_env("production", &["delete"])
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let in_prod = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"delete\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"environment": "production"}}),
+    );
+    assert_eq!(in_prod, cedar_policy::Decision::Deny);
+
+    let in_staging = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"delete\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"environment": "staging"}}),
+    );
+    assert_eq!(in_staging, cedar_policy::Decision::Allow);
+}
+
+#[test]
+fn test_consent_required_before_action() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("user", &["search", "send_email"])
+        .user("alice", &["user"])
+        .consent_all("send_email")
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let without_consent = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"send_email\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {}}),
+    );
+    assert_eq!(without_consent, cedar_policy::Decision::Deny);
+
+    let with_consent = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"send_email\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"user_consent": true}}),
+    );
+    assert_eq!(with_consent, cedar_policy::Decision::Allow);
+
+    let other_tool_no_consent_needed = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"search\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({}),
+    );
+    assert_eq!(other_tool_no_consent_needed, cedar_policy::Decision::Allow);
+}
+
+#[test]
+fn test_restriction_enforces_allowed_values() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("analyst", &["query"])
+        .user("bob", &["analyst"])
+        .restrict(
+            "query",
+            BTreeMap::from([("database".to_string(), vec![serde_json::json!("analytics")])]),
+        )
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let allowed_db = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"query\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"input": {"database": "analytics"}}),
+    );
+    assert_eq!(allowed_db, cedar_policy::Decision::Allow);
+
+    let disallowed_db = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"query\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"input": {"database": "production"}}),
+    );
+    assert_eq!(disallowed_db, cedar_policy::Decision::Deny);
+}
+
+#[test]
+fn test_custom_namespace_and_principal_type() {
+    let result = CedarAgentPolicyBuilder::new()
+        .namespace("MyApp")
+        .unwrap()
+        .principal("sub", "Agent")
+        .unwrap()
+        .role("admin", &["*"])
+        .user("alice", &["admin"])
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let decision = authorize(
+        &result.policies,
+        &entities_json,
+        "MyApp::Agent::\"alice\"",
+        "MyApp::Action::\"anything\"",
+        "MyApp::Resource::\"default\"",
+        serde_json::json!({}),
+    );
+    assert_eq!(decision, cedar_policy::Decision::Allow);
+}
+
+#[test]
+fn test_multi_role_user_inherits_all_permissions() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("reader", &["search"])
+        .role("writer", &["create", "update"])
+        .user("charlie", &["reader", "writer"])
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    for action in &["search", "create", "update"] {
+        let decision = authorize(
+            &result.policies,
+            &entities_json,
+            "Agent::User::\"charlie\"",
+            &format!("Agent::Action::\"{action}\""),
+            "Agent::Resource::\"default\"",
+            serde_json::json!({}),
+        );
+        assert_eq!(
+            decision,
+            cedar_policy::Decision::Allow,
+            "charlie should be allowed {action}"
+        );
+    }
+
+    let denied = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"charlie\"",
+        "Agent::Action::\"delete\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({}),
+    );
+    assert_eq!(denied, cedar_policy::Decision::Deny);
+}
+
+#[test]
+fn test_combined_policies_all_interact_correctly() {
+    let result = CedarAgentPolicyBuilder::new()
+        .namespace("Agent")
+        .unwrap()
+        .principal("sub", "User")
+        .unwrap()
+        .role("admin", &["*"])
+        .role("analyst", &["search", "query", "send_email"])
+        .user("alice", &["admin"])
+        .user("bob", &["analyst"])
+        .rate_limit("send_email", 3)
+        .time_window("*", (9, 17))
+        .unwrap()
+        .consent_all("send_email")
+        .deny_in_env("production", &["delete"])
+        .restrict(
+            "query",
+            BTreeMap::from([(
+                "database".to_string(),
+                vec![
+                    serde_json::json!("analytics"),
+                    serde_json::json!("reporting"),
+                ],
+            )]),
+        )
+        .build();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    // Admin can do anything in working hours
+    let admin_ok = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"search\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 10}}),
+    );
+    assert_eq!(admin_ok, cedar_policy::Decision::Allow);
+
+    // Admin blocked outside hours
+    let admin_after_hours = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"search\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 22}}),
+    );
+    assert_eq!(admin_after_hours, cedar_policy::Decision::Deny);
+
+    // Admin blocked from delete in production
+    let admin_delete_prod = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"delete\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 10, "environment": "production"}}),
+    );
+    assert_eq!(admin_delete_prod, cedar_policy::Decision::Deny);
+
+    // Analyst can search in working hours
+    let analyst_search = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"search\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 10}}),
+    );
+    assert_eq!(analyst_search, cedar_policy::Decision::Allow);
+
+    // Analyst query with allowed database works
+    let analyst_query_ok = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"query\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 10}, "input": {"database": "analytics"}}),
+    );
+    assert_eq!(analyst_query_ok, cedar_policy::Decision::Allow);
+
+    // Analyst query with disallowed database blocked
+    let analyst_query_bad = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"query\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 10}, "input": {"database": "users"}}),
+    );
+    assert_eq!(analyst_query_bad, cedar_policy::Decision::Deny);
+
+    // Analyst send_email needs consent AND under rate limit
+    let analyst_email_with_consent = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"send_email\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 10, "user_consent": true, "call_count_send_email": 2}}),
+    );
+    assert_eq!(analyst_email_with_consent, cedar_policy::Decision::Allow);
+
+    // Analyst send_email over rate limit blocked
+    let analyst_email_over_limit = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"bob\"",
+        "Agent::Action::\"send_email\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": 10, "user_consent": true, "call_count_send_email": 3}}),
+    );
+    assert_eq!(analyst_email_over_limit, cedar_policy::Decision::Deny);
+}


### PR DESCRIPTION
## Description of changes

Rust implementation of the policy builder (mirrors `js/cedar-agent-policy-builder/` from previous pr). Takes a declarative config and produces Cedar policies, entities, and a schema — same output format as the TS version.

Uses the entity hierarchy model from #2 (`principal in Role::"name"`, users with role parents). Schema generation delegates to `cedar-policy-mcp-schema-generator`.

### Changes addressing review feedback

- **Bracket access syntax**: Use `context.input["field"]` instead of `context.input.field` to safely handle fields with special characters (e.g. hyphens)
- **Identifier validation**: `namespace()`, `principal()`, and `resource()` now validate inputs using Cedar's own `ast::Id` parser, rejecting reserved words and invalid identifiers at build time
- **Cedar-native escaping**: Replaced manual `escape_cedar_string` with `EntityId::escaped()` from the `cedar-policy` crate

WASI binary, WASM bindings, and Python bindings will follow in a separate PR.

## Issue #, if available

N/A

## Checklist for requesting a review

The change in this PR is:

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR:

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.