### PR TITLE
feat: add cedar policy agent builder to crates.io publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 # This workflow is for releasing either:
 #.    - mcp-tools-sdk
 #.    - cedar-policy-mcp-schema-generator
+#.    - cedar-policy-agent-builder
 # Notes:
 # - This workflow must be triggered from the main branch.
 # - This workflow will perform the release from the provided tag, which must be set in advance.
@@ -18,6 +19,7 @@ on:
                 options:
                     - mcp-tools-sdk
                     - cedar-policy-mcp-schema-generator
+                    - cedar-policy-agent-builder
             tag:
                 required: true
                 type: string

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -261,14 +261,15 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "4.11.2"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd98501120bc31fc09f92d3f58c489f4ee4b846904109ac63dd8256de7b84d"
+checksum = "f73547a0114dff845fcb8d4877548a665fb8ff949a30cb0963444d6c30ffd962"
 dependencies = [
  "cedar-policy-core",
  "cedar-policy-formatter",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "linked-hash-map",
+ "linked_hash_set",
  "miette",
  "ref-cast",
  "semver",
@@ -284,7 +285,6 @@ name = "cedar-policy-agent-builder"
 version = "0.1.0"
 dependencies = [
  "cedar-policy",
- "cedar-policy-core",
  "cedar-policy-mcp-schema-generator",
  "mcp-tools-sdk",
  "serde",
@@ -322,12 +322,12 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "4.11.2"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6c28be47d77dcbc04c2a80181a2c0db9725ed60d24832c6401396cc2ae114b"
+checksum = "2483b2fa74f74b1b3945bec59feb7a3fc0ea56b6fb35564ef300884dd8415d4b"
 dependencies = [
  "cedar-policy-core",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "logos",
  "miette",
  "pretty",
@@ -951,7 +951,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/rust/cedar-policy-agent-builder/CHANGELOG.md
+++ b/rust/cedar-policy-agent-builder/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - Coming soon
+
+### Added
+- Fluent `CedarAgentPolicyBuilder` API for generating Cedar policies, entities, and schemas from declarative configuration.
+- Role-based access control with `permit` policies scoped to role membership.
+- Rate limiting via `forbid` policies conditioned on session call counters.
+- UTC time window restrictions for tool access.
+- Environment-based denial policies (e.g., deny destructive tools in production).
+- User consent gates requiring explicit approval before tool execution.
+- Input field restrictions limiting tool parameters to allowed values.
+- Cedar schema generation from MCP tool definitions.
+- Policy validation against generated schemas.
+- Custom namespace, principal type, and resource entity configuration.

--- a/rust/cedar-policy-agent-builder/Cargo.toml
+++ b/rust/cedar-policy-agent-builder/Cargo.toml
@@ -12,9 +12,9 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator" }
-mcp-tools-sdk = { path = "../mcp-tools-sdk" }
-cedar-policy = ">= 4.11"
+cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator", version = "*" }
+mcp-tools-sdk = { path = "../mcp-tools-sdk", version = "*" }
+cedar-policy = ">= 4.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/rust/cedar-policy-agent-builder/Cargo.toml
+++ b/rust/cedar-policy-agent-builder/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 [dependencies]
 cedar-policy-mcp-schema-generator = { path = "../cedar-policy-mcp-schema-generator", version = "*" }
 mcp-tools-sdk = { path = "../mcp-tools-sdk", version = "*" }
-cedar-policy = ">= 4.12"
+cedar-policy = ">= 4.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"


### PR DESCRIPTION
## Description of changes

Adds `cedar-policy-agent-builder` to the crates.io publish workflow and prepares the crate for publishing:

- Adds the crate as a new option in the `publish.yml` workflow dispatch dropdown
- Adds `version = "*"` to path dependencies (`cedar-policy-mcp-schema-generator`, `mcp-tools-sdk`) so `cargo publish` accepts them
- Updates `cedar-policy` dependency to `>= 4.12` to match the workspace lockfile
- Creates `CHANGELOG.md` following existing crate conventions

## Issue #, if available

N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to non public-facing "internal" APIs)

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).