### PR TITLE
sanitizing config inputs

### DIFF
--- a/rust/cedar-policy-agent-builder/src/builder.rs
+++ b/rust/cedar-policy-agent-builder/src/builder.rs
@@ -229,7 +229,7 @@ impl CedarAgentPolicyBuilder {
 
     /// Consume the builder and generate Cedar policies, entities, and schema.
     ///
-    /// Returns an error if configuration validation fails. In pratice, this does
+    /// Returns an error if configuration validation fails. In practice, this does
     /// not fail when using only the builder methods.
     pub fn build(self) -> Result<BuildResult, crate::ConfigValidationError> {
         crate::build(&self.config)

--- a/rust/cedar-policy-agent-builder/src/builder.rs
+++ b/rust/cedar-policy-agent-builder/src/builder.rs
@@ -36,7 +36,8 @@ fn validate_cedar_ident(s: &str) -> Result<(), BuilderError> {
 ///     .user("bob", &["analyst"])
 ///     .rate_limit("search", 100)
 ///     .time_window("*", (9, 17)).unwrap()
-///     .build();
+///     .build()
+///     .unwrap();
 ///
 /// assert!(!result.policies.is_empty());
 /// ```
@@ -227,7 +228,10 @@ impl CedarAgentPolicyBuilder {
     }
 
     /// Consume the builder and generate Cedar policies, entities, and schema.
-    pub fn build(self) -> BuildResult {
+    ///
+    /// Returns an error if configuration validation fails. In pratice, this does
+    /// not fail when using only the builder methods.
+    pub fn build(self) -> Result<BuildResult, crate::ConfigValidationError> {
         crate::build(&self.config)
     }
 }
@@ -253,7 +257,8 @@ mod tests {
         let result = CedarAgentPolicyBuilder::new()
             .role("admin", &["*"])
             .user("alice", &["admin"])
-            .build();
+            .build()
+            .unwrap();
 
         assert!(result
             .policies
@@ -268,7 +273,8 @@ mod tests {
             .namespace("MyApp")
             .unwrap()
             .role("viewer", &["read"])
-            .build();
+            .build()
+            .unwrap();
 
         assert!(result.policies.contains("MyApp::Role::\"viewer\""));
         assert!(result.policies.contains("MyApp::Action::\"read\""));
@@ -290,7 +296,8 @@ mod tests {
             .unwrap()
             .consent_all("send_email")
             .deny_in_env("production", &["delete"])
-            .build();
+            .build()
+            .unwrap();
 
         assert!(result.policies.contains("Role::\"admin\""));
         assert!(result.policies.contains("Role::\"analyst\""));
@@ -303,7 +310,7 @@ mod tests {
     #[test]
     fn test_builder_default() {
         let builder = CedarAgentPolicyBuilder::default();
-        let result = builder.build();
+        let result = builder.build().unwrap();
         assert!(result.policies.is_empty());
         assert_eq!(result.entities.len(), 1); // just the default resource
     }
@@ -330,7 +337,8 @@ mod tests {
                 "query",
                 BTreeMap::from([("db".to_string(), vec![serde_json::json!("analytics")])]),
             )
-            .build();
+            .build()
+            .unwrap();
 
         assert_policies_parse(&result);
     }
@@ -340,7 +348,8 @@ mod tests {
         let result = CedarAgentPolicyBuilder::new()
             .role("admin", &["*"])
             .user("alice", &["admin"])
-            .build();
+            .build()
+            .unwrap();
 
         assert_policies_parse(&result);
     }
@@ -371,7 +380,8 @@ mod tests {
                 input_schema: serde_json::json!({"type": "object", "properties": {"q": {"type": "string"}}}),
                 output_schema: None,
             })
-            .build();
+            .build()
+            .unwrap();
 
         assert!(result.schema.is_some());
         assert!(result.schema_errors.is_empty());
@@ -383,7 +393,8 @@ mod tests {
             .resource("Gateway", "prod")
             .unwrap()
             .role("admin", &["*"])
-            .build();
+            .build()
+            .unwrap();
 
         let resource = result.entities.iter().find(|e| e.uid.id == "prod").unwrap();
         assert_eq!(resource.uid.entity_type, "Agent::Gateway");
@@ -395,7 +406,8 @@ mod tests {
             .role("admin", &["*"])
             .role("analyst", &["search", "deploy"])
             .consent_for_roles("deploy", &["admin"])
-            .build();
+            .build()
+            .unwrap();
 
         assert!(result.policies.contains("user_consent"));
         assert!(result.policies.contains("Role::\"admin\""));
@@ -407,7 +419,8 @@ mod tests {
             .role("admin", &["*"])
             .time_window("deploy", (9, 17))
             .unwrap()
-            .build();
+            .build()
+            .unwrap();
 
         assert!(result.policies.contains("Action::\"deploy\""));
         assert!(result.policies.contains("hour_utc"));

--- a/rust/cedar-policy-agent-builder/src/config.rs
+++ b/rust/cedar-policy-agent-builder/src/config.rs
@@ -3,14 +3,18 @@
 //! These types define the declarative input that drives policy generation.
 //! They can be deserialized from JSON/YAML or constructed via [`CedarAgentPolicyBuilder`](crate::CedarAgentPolicyBuilder).
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
 
 /// Configuration for the principal (user/agent) entity type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrincipalConfig {
     pub key: String,
-    #[serde(rename = "type", default = "default_principal_type")]
+    #[serde(
+        rename = "type",
+        default = "default_principal_type",
+        deserialize_with = "deserialize_cedar_ident"
+    )]
     pub principal_type: String,
 }
 
@@ -30,7 +34,11 @@ impl Default for PrincipalConfig {
 /// Configuration for the resource entity (the thing being accessed).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResourceConfig {
-    #[serde(rename = "type", default = "default_resource_type")]
+    #[serde(
+        rename = "type",
+        default = "default_resource_type",
+        deserialize_with = "deserialize_cedar_ident"
+    )]
     pub resource_type: String,
     #[serde(default = "default_resource_id")]
     pub id: String,
@@ -135,7 +143,10 @@ pub struct CedarAgentConfig {
     #[serde(default)]
     pub tools: Option<Vec<McpToolDefinition>>,
     /// Cedar namespace (default: `"Agent"`).
-    #[serde(default = "default_namespace")]
+    #[serde(
+        default = "default_namespace",
+        deserialize_with = "deserialize_namespace"
+    )]
     pub namespace: String,
 }
 
@@ -159,4 +170,76 @@ impl Default for CedarAgentConfig {
             namespace: default_namespace(),
         }
     }
+}
+
+/// Errors returned when a [`CedarAgentConfig`] contains invalid identifier fields.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConfigValidationError {
+    /// The `namespace` field is not a valid Cedar identifier.
+    #[error("invalid namespace \"{value}\": not a valid Cedar identifier")]
+    InvalidNamespace { value: String },
+    /// The `principal.type` field is not a valid Cedar identifier.
+    #[error("invalid principal type \"{value}\": not a valid Cedar identifier")]
+    InvalidPrincipalType { value: String },
+    /// The `resource.type` field is not a valid Cedar identifier.
+    #[error("invalid resource type \"{value}\": not a valid Cedar identifier")]
+    InvalidResourceType { value: String },
+}
+
+/// Check whether a string is a valid Cedar identifier (namespace path segment or entity type name).
+///
+/// Uses the Cedar parser to reject reserved words, invalid characters, and injection attempts.
+fn is_valid_cedar_ident(s: &str) -> bool {
+    cedar_policy::pst::Id::new(s).is_ok()
+}
+
+/// Validate all identifier-like fields in a [`CedarAgentConfig`].
+///
+/// Returns the first validation error found, or `Ok(())` if all fields are valid.
+/// Call this before policy/entity generation when the config was deserialized from
+/// an untrusted source (JSON, YAML, API input).
+pub fn validate_config(config: &CedarAgentConfig) -> Result<(), ConfigValidationError> {
+    if !is_valid_cedar_ident(&config.namespace) {
+        return Err(ConfigValidationError::InvalidNamespace {
+            value: config.namespace.clone(),
+        });
+    }
+    if !is_valid_cedar_ident(&config.principal.principal_type) {
+        return Err(ConfigValidationError::InvalidPrincipalType {
+            value: config.principal.principal_type.clone(),
+        });
+    }
+    if let Some(resource) = &config.resource {
+        if !is_valid_cedar_ident(&resource.resource_type) {
+            return Err(ConfigValidationError::InvalidResourceType {
+                value: resource.resource_type.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Serde deserializer that validates a string is a valid Cedar identifier.
+///
+/// Rejects values that could enable policy injection when interpolated into Cedar text.
+fn deserialize_cedar_ident<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    if is_valid_cedar_ident(&s) {
+        Ok(s)
+    } else {
+        Err(serde::de::Error::custom(format!(
+            "\"{s}\" is not a valid Cedar identifier"
+        )))
+    }
+}
+
+/// Serde deserializer for namespace with default + validation.
+fn deserialize_namespace<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_cedar_ident(deserializer)
 }

--- a/rust/cedar-policy-agent-builder/src/lib.rs
+++ b/rust/cedar-policy-agent-builder/src/lib.rs
@@ -21,7 +21,8 @@
 //!     .rate_limit("send_email", 5)
 //!     .time_window("*", (9, 17)).unwrap()
 //!     .deny_in_env("production", &["delete"])
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //!
 //! // `result.policies` is valid Cedar policy text
 //! // `result.entities` is the entity hierarchy (serialize to JSON for the authorizer)
@@ -57,6 +58,7 @@ pub mod entities;
 pub mod policy;
 
 pub use builder::{BuilderError, CedarAgentPolicyBuilder};
+pub use config::ConfigValidationError;
 
 use cedar_policy::{PolicySet, Schema, ValidationMode, Validator};
 use config::CedarAgentConfig;
@@ -204,9 +206,15 @@ impl std::fmt::Display for SchemaError {
 
 /// Build Cedar policies, entities, and schema from a configuration struct.
 ///
+/// Validates all identifier-like fields (`namespace`, `principal.type`, `resource.type`)
+/// before generating policy text. Returns an error if any field contains a value that
+/// is not a valid Cedar identifier, which would otherwise allow policy injection.
+///
 /// Prefer [`CedarAgentPolicyBuilder`] for a fluent API. This function is the
 /// lower-level entry point used internally by the builder.
-pub fn build(config: &CedarAgentConfig) -> BuildResult {
+pub fn build(config: &CedarAgentConfig) -> Result<BuildResult, ConfigValidationError> {
+    config::validate_config(config)?;
+
     let policies = generate_policies(config);
     let entities = generate_entities(config);
     let (schema, schema_errors) = match generate_schema(config) {
@@ -214,12 +222,12 @@ pub fn build(config: &CedarAgentConfig) -> BuildResult {
         Err(e) => (None, vec![e]),
     };
 
-    BuildResult {
+    Ok(BuildResult {
         policies,
         entities,
         schema,
         schema_errors,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -247,7 +255,7 @@ mod tests {
             }]),
             ..Default::default()
         };
-        let result = build(&config);
+        let result = build(&config).unwrap();
         assert!(result.schema.is_some());
         assert!(result.schema_errors.is_empty());
         let schema = result.schema.unwrap();
@@ -263,7 +271,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let result = build(&config);
+        let result = build(&config).unwrap();
         assert!(result.schema.is_none());
         assert!(result.schema_errors.is_empty());
     }
@@ -279,7 +287,7 @@ mod tests {
             }]),
             ..Default::default()
         };
-        let result = build(&config);
+        let result = build(&config).unwrap();
         assert!(!result.schema_errors.is_empty());
         assert!(result.schema.is_none());
         assert!(!result.schema_errors[0].message.is_empty());
@@ -302,7 +310,7 @@ mod tests {
             }]),
             ..Default::default()
         };
-        let result = build(&config);
+        let result = build(&config).unwrap();
         assert!(result.schema.is_some());
         assert!(result.schema_errors.is_empty());
     }
@@ -363,7 +371,7 @@ mod tests {
             }]),
             ..Default::default()
         };
-        let result = build(&config);
+        let result = build(&config).unwrap();
         assert!(result.schema.is_some());
         assert!(result.schema_errors.is_empty());
         let schema = result.schema.unwrap();
@@ -376,7 +384,7 @@ mod tests {
             tools: Some(vec![]),
             ..Default::default()
         };
-        let result = build(&config);
+        let result = build(&config).unwrap();
         assert!(result.schema.is_none());
         assert!(result.schema_errors.is_empty());
     }
@@ -391,6 +399,88 @@ mod tests {
             err.to_string(),
             "schema generation failed at test_stage: something broke"
         );
+    }
+
+    #[test]
+    fn test_build_rejects_invalid_namespace() {
+        let config = CedarAgentConfig {
+            namespace: "Attack::Role::\"admin\"; permit(principal, action, resource); //"
+                .to_string(),
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigValidationError::InvalidNamespace { .. }
+        ));
+    }
+
+    #[test]
+    fn test_build_rejects_invalid_principal_type() {
+        let config = CedarAgentConfig {
+            principal: config::PrincipalConfig {
+                key: "user_id".to_string(),
+                principal_type: "Bad Type".to_string(),
+            },
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigValidationError::InvalidPrincipalType { .. }
+        ));
+    }
+
+    #[test]
+    fn test_build_rejects_invalid_resource_type() {
+        let config = CedarAgentConfig {
+            resource: Some(config::ResourceConfig {
+                resource_type: "foo bar".to_string(),
+                id: "default".to_string(),
+            }),
+            ..Default::default()
+        };
+        let result = build(&config);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigValidationError::InvalidResourceType { .. }
+        ));
+    }
+
+    #[test]
+    fn test_serde_rejects_invalid_namespace() {
+        let json = r#"{"namespace": "Bad::Ns; permit(principal, action, resource);"}"#;
+        let result: Result<CedarAgentConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("not a valid Cedar identifier"));
+    }
+
+    #[test]
+    fn test_serde_rejects_invalid_principal_type() {
+        let json = r#"{"principal": {"key": "sub", "type": "has spaces"}}"#;
+        let result: Result<CedarAgentConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_serde_rejects_invalid_resource_type() {
+        let json = r#"{"resource": {"type": "inject;", "id": "x"}}"#;
+        let result: Result<CedarAgentConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_serde_accepts_valid_namespace() {
+        let json = r#"{"namespace": "MyAgent"}"#;
+        let config: CedarAgentConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.namespace, "MyAgent");
     }
 }
 

--- a/rust/cedar-policy-agent-builder/tests/authorization.rs
+++ b/rust/cedar-policy-agent-builder/tests/authorization.rs
@@ -34,7 +34,8 @@ fn test_admin_allowed_any_action() {
     let result = CedarAgentPolicyBuilder::new()
         .role("admin", &["*"])
         .user("alice", &["admin"])
-        .build();
+        .build()
+        .unwrap();
 
     let decision = authorize(
         &result.policies,
@@ -52,7 +53,8 @@ fn test_unknown_user_denied() {
     let result = CedarAgentPolicyBuilder::new()
         .role("admin", &["*"])
         .user("alice", &["admin"])
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
     let entities_with_bob = {
@@ -81,7 +83,8 @@ fn test_role_scoped_to_specific_tools() {
     let result = CedarAgentPolicyBuilder::new()
         .role("analyst", &["search", "query"])
         .user("bob", &["analyst"])
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -112,7 +115,8 @@ fn test_rate_limit_denies_when_exceeded() {
         .role("user", &["send_email"])
         .user("alice", &["user"])
         .rate_limit("send_email", 5)
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -144,7 +148,8 @@ fn test_time_window_denies_outside_hours() {
         .user("alice", &["user"])
         .time_window("deploy", (9, 17))
         .unwrap()
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -175,7 +180,8 @@ fn test_env_denial_blocks_in_production() {
         .role("admin", &["*"])
         .user("alice", &["admin"])
         .deny_in_env("production", &["delete"])
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -206,7 +212,8 @@ fn test_consent_required_before_action() {
         .role("user", &["search", "send_email"])
         .user("alice", &["user"])
         .consent_all("send_email")
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -250,7 +257,8 @@ fn test_restriction_enforces_allowed_values() {
             "query",
             BTreeMap::from([("database".to_string(), vec![serde_json::json!("analytics")])]),
         )
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -284,7 +292,8 @@ fn test_custom_namespace_and_principal_type() {
         .unwrap()
         .role("admin", &["*"])
         .user("alice", &["admin"])
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -305,7 +314,8 @@ fn test_multi_role_user_inherits_all_permissions() {
         .role("reader", &["search"])
         .role("writer", &["create", "update"])
         .user("charlie", &["reader", "writer"])
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -362,7 +372,8 @@ fn test_combined_policies_all_interact_correctly() {
                 ],
             )]),
         )
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -465,7 +476,8 @@ fn test_consent_all_does_not_grant_to_unauthorized_roles() {
         .user("alice", &["sender"])
         .user("bob", &["viewer"])
         .consent_all("send_email")
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 
@@ -499,7 +511,8 @@ fn test_consent_all_denies_unknown_principal() {
         .role("user", &["send_email"])
         .user("alice", &["user"])
         .consent_all("send_email")
-        .build();
+        .build()
+        .unwrap();
 
     let entities_json = entities_to_json(&result.entities);
 


### PR DESCRIPTION
Adding some validation in the config to prevent policy injection in names.
As a result, we have to make the build method fallible.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.