### PR TITLE
forbid policies dependent on sesion info now forbid when missing info

### DIFF
--- a/rust/cedar-policy-agent-builder/src/lib.rs
+++ b/rust/cedar-policy-agent-builder/src/lib.rs
@@ -63,7 +63,7 @@ pub use config::ConfigValidationError;
 use cedar_policy::{PolicySet, Schema, ValidationMode, Validator};
 use config::CedarAgentConfig;
 use entities::{generate_entities, EntityJson};
-use policy::generate_policies;
+use policy::PolicyGenerator;
 use serde::{Deserialize, Serialize};
 
 /// A single validation error or warning from Cedar's policy validator.
@@ -214,8 +214,7 @@ impl std::fmt::Display for SchemaError {
 /// lower-level entry point used internally by the builder.
 pub fn build(config: &CedarAgentConfig) -> Result<BuildResult, ConfigValidationError> {
     config::validate_config(config)?;
-
-    let policies = generate_policies(config);
+    let policies = PolicyGenerator::generate_policies(config);
     let entities = generate_entities(config);
     let (schema, schema_errors) = match generate_schema(config) {
         Ok(s) => (s, Vec::new()),

--- a/rust/cedar-policy-agent-builder/src/policy.rs
+++ b/rust/cedar-policy-agent-builder/src/policy.rs
@@ -1,6 +1,6 @@
 use crate::config::{CedarAgentConfig, ConsentScope};
 use cedar_policy::EntityId;
-use std::{collections::BTreeSet, io::ErrorKind::ConnectionRefused};
+use std::collections::BTreeSet;
 
 fn action_ref(ns: &str, name: &str) -> String {
     let eid = EntityId::new(name);

--- a/rust/cedar-policy-agent-builder/src/policy.rs
+++ b/rust/cedar-policy-agent-builder/src/policy.rs
@@ -25,7 +25,7 @@ fn normalize_consent_roles(scope: &ConsentScope) -> Vec<&str> {
 /// Get the roles that grant access to the given `tool`.
 /// A role grants access to a tool if either it grants access to any tool via `"*"` or it
 /// grants access to that specific tool.
-fn get_roles_granting_tool<'a>(config: &'a CedarAgentConfig, tool: &str) -> Vec<&'a str> {
+fn get_roles_granting_tool(config: &CedarAgentConfig, tool: &str) -> Vec<String> {
     let roles = match &config.roles {
         Some(r) => r,
         None => return Vec::new(),
@@ -33,7 +33,7 @@ fn get_roles_granting_tool<'a>(config: &'a CedarAgentConfig, tool: &str) -> Vec<
     roles
         .iter()
         .filter(|(_, tools)| tools.iter().any(|t| t == "*" || t == tool))
-        .map(|(role_name, _)| role_name.as_str())
+        .map(|(role_name, _)| role_name.clone())
         .collect()
 }
 
@@ -50,196 +50,224 @@ fn get_consent_tools_for_role(config: &CedarAgentConfig, role_name: &str) -> BTr
     tools
 }
 
-fn generate_role_policies(config: &CedarAgentConfig) -> Vec<String> {
-    let roles = match &config.roles {
-        Some(r) => r,
-        None => return Vec::new(),
-    };
-    let ns = &config.namespace;
-    let mut policies = Vec::new();
+/// A [`PolicyGenerator`] generates the policy text from a `config`, keeping track of additional
+/// state as it generates those policies.
+// We may want to use this to store additional state when doing policy generation.
+#[derive(Debug)]
+pub struct PolicyGenerator<'a> {
+    config: &'a CedarAgentConfig,
+    policies_text: Vec<String>,
+}
 
-    for (role_name, tools) in roles {
-        let consent_tools = get_consent_tools_for_role(config, role_name);
-        let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role_name).escaped());
+impl<'a> PolicyGenerator<'a> {
+    fn generate_role_policies(&mut self) {
+        let roles = match &self.config.roles {
+            Some(r) => r,
+            None => return,
+        };
+        let ns = &self.config.namespace;
+        let mut policies = Vec::new();
 
-        if tools.contains(&"*".to_string()) {
-            if consent_tools.is_empty() {
-                policies.push(format!(
-                    "permit(principal in {role_ref}, action, resource);"
-                ));
-            } else {
-                let exclusions: Vec<String> =
-                    consent_tools.iter().map(|t| action_ref(ns, t)).collect();
-                policies.push(format!(
+        for (role_name, tools) in roles {
+            let consent_tools = get_consent_tools_for_role(self.config, role_name);
+            let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role_name).escaped());
+
+            if tools.contains(&"*".to_string()) {
+                if consent_tools.is_empty() {
+                    policies.push(format!(
+                        "permit(principal in {role_ref}, action, resource);"
+                    ));
+                } else {
+                    let exclusions: Vec<String> =
+                        consent_tools.iter().map(|t| action_ref(ns, t)).collect();
+                    policies.push(format!(
                     "permit(\n  principal in {role_ref},\n  action,\n  resource\n) when {{ !({}) }};",
                     exclusions.join(" || ")
                 ));
-            }
-        } else {
-            let filtered: Vec<&String> = tools
-                .iter()
-                .filter(|t| !consent_tools.contains(t.as_str()))
-                .collect();
-            for tool in filtered {
-                policies.push(format!(
-                    "permit(principal in {role_ref}, {}, resource);",
-                    action_ref(ns, tool)
-                ));
+                }
+            } else {
+                let filtered: Vec<&String> = tools
+                    .iter()
+                    .filter(|t| !consent_tools.contains(t.as_str()))
+                    .collect();
+                for tool in filtered {
+                    policies.push(format!(
+                        "permit(principal in {role_ref}, {}, resource);",
+                        action_ref(ns, tool)
+                    ));
+                }
             }
         }
+
+        self.policies_text.append(&mut policies);
     }
 
-    policies
-}
+    fn generate_restriction_policies(&mut self) {
+        let restrictions = match &self.config.restrictions {
+            Some(r) => r,
+            None => return,
+        };
+        let ns = &self.config.namespace;
+        let mut policies = Vec::new();
 
-fn generate_restriction_policies(config: &CedarAgentConfig) -> Vec<String> {
-    let restrictions = match &config.restrictions {
-        Some(r) => r,
-        None => return Vec::new(),
-    };
-    let ns = &config.namespace;
-    let mut policies = Vec::new();
-
-    for (tool, restriction) in restrictions {
-        let action_clause = action_ref(ns, tool);
-        if restriction.allowed_values.is_empty() {
-            policies.push(format!(
-                "forbid(\n  principal,\n  {action_clause},\n  resource\n);"
-            ));
-            continue;
-        }
-        for (field, allowed_values) in &restriction.allowed_values {
-            let value_checks: Vec<String> = allowed_values
-                .iter()
-                .map(|v| {
-                    let formatted = format_cedar_value(v);
-                    format!(
-                        "context.input[\"{}\"] == {formatted}",
-                        EntityId::new(field).escaped()
-                    )
-                })
-                .collect();
-            policies.push(format!(
+        for (tool, restriction) in restrictions {
+            let action_clause = action_ref(ns, tool);
+            if restriction.allowed_values.is_empty() {
+                policies.push(format!(
+                    "forbid(\n  principal,\n  {action_clause},\n  resource\n);"
+                ));
+                continue;
+            }
+            for (field, allowed_values) in &restriction.allowed_values {
+                let value_checks: Vec<String> = allowed_values
+                    .iter()
+                    .map(|v| {
+                        let formatted = format_cedar_value(v);
+                        format!(
+                            "context.input[\"{}\"] == {formatted}",
+                            EntityId::new(field).escaped()
+                        )
+                    })
+                    .collect();
+                policies.push(format!(
                 "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{\n  !(context.input has \"{}\" && ({}))\n}};",
                 EntityId::new(field).escaped(),
                 value_checks.join(" || ")
             ));
+            }
         }
+
+        self.policies_text.append(&mut policies);
     }
 
-    policies
-}
+    fn generate_rate_limit_policies(&mut self) {
+        let rate_limits = match &self.config.rate_limits {
+            Some(r) => r,
+            None => return,
+        };
+        let ns = &self.config.namespace;
+        let mut policies = Vec::new();
 
-fn generate_rate_limit_policies(config: &CedarAgentConfig) -> Vec<String> {
-    let rate_limits = match &config.rate_limits {
-        Some(r) => r,
-        None => return Vec::new(),
-    };
-    let ns = &config.namespace;
-    let mut policies = Vec::new();
-
-    for (tool, max) in rate_limits {
-        if tool == "*" {
-            policies.push(format!(
-                "forbid(\n  principal,\n  action,\n  resource\n) when {{ context.session has \"call_count\" && context.session.call_count >= {max} }};",
-            ));
-        } else {
-            let action_clause = action_ref(ns, tool);
-            let counter_key = format!("call_count_{}", sanitize_counter_key(tool));
-            policies.push(format!(
-                "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{ context.session has \"{}\" && context.session.{} >= {max} }};",
+        for (tool, max) in rate_limits {
+            if tool == "*" {
+                // forbid if call count not provided, or call count is too large
+                policies.push(format!(
+                    "forbid(\n  principal,\n  action,\n  resource\n) when {{ !(context.session has \"call_count\") || context.session.call_count >= {max} }};",
+                ));
+            } else {
+                let action_clause = action_ref(ns, tool);
+                let counter_key = format!("call_count_{}", sanitize_counter_key(tool));
+                // forbid if call count not provided for this tool, or call count is too large
+                policies.push(format!(
+                "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{ !(context.session has \"{}\") || context.session.{} >= {max} }};",
                 counter_key,
                 counter_key
-            ));
+                ));
+            }
         }
+
+        self.policies_text.append(&mut policies);
     }
 
-    policies
-}
-
-fn generate_time_window_policies(config: &CedarAgentConfig) -> Vec<String> {
-    let time_windows = match &config.time_windows {
-        Some(t) => t,
-        None => return Vec::new(),
-    };
-    let ns = &config.namespace;
-    let mut policies = Vec::new();
-
-    for (tool, tw) in time_windows {
-        let action_clause = if tool == "*" {
-            "action".to_string()
-        } else {
-            action_ref(ns, tool)
+    fn generate_time_window_policies(&mut self) {
+        let time_windows = match &self.config.time_windows {
+            Some(t) => t,
+            None => return,
         };
-        policies.push(format!(
-            "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{ context.session has \"hour_utc\" && (context.session.hour_utc < {} || context.session.hour_utc >= {}) }};",
-            tw.hour_start, tw.hour_end
-        ));
+        let ns = &self.config.namespace;
+        let mut policies = Vec::new();
+
+        for (tool, tw) in time_windows {
+            let action_clause = if tool == "*" {
+                "action".to_string()
+            } else {
+                action_ref(ns, tool)
+            };
+            // forbid if hour_utc not provided, or outside of specified window
+            policies.push(format!(
+                "forbid(\n  principal,\n  {action_clause},\n  resource\n) when {{ !(context.session has \"hour_utc\") || (context.session.hour_utc < {} || context.session.hour_utc >= {}) }};",
+                tw.hour_start, tw.hour_end));
+        }
+        self.policies_text.append(&mut policies);
     }
 
-    policies
-}
+    fn generate_env_denial_policies(&mut self) {
+        let deny_in_env = match &self.config.deny_in_env {
+            Some(d) => d,
+            None => return,
+        };
+        let ns = &self.config.namespace;
+        let mut policies = Vec::new();
 
-fn generate_env_denial_policies(config: &CedarAgentConfig) -> Vec<String> {
-    let deny_in_env = match &config.deny_in_env {
-        Some(d) => d,
-        None => return Vec::new(),
-    };
-    let ns = &config.namespace;
-    let mut policies = Vec::new();
-    for (env, tools) in deny_in_env {
-        if tools.contains(&"*".to_string()) {
-            policies.push(format!(
-                "forbid(\n  principal,\n  action,\n  resource\n) when {{ context.session has \"environment\" && context.session.environment == \"{}\" }};",
+        for (env, tools) in deny_in_env {
+            if tools.contains(&"*".to_string()) {
+                // forbid if environment not provided, or environment is the denied one
+                policies.push(format!(
+                "forbid(\n  principal,\n  action,\n  resource\n) when {{ !(context.session has \"environment\") || context.session.environment == \"{}\" }};",
                 EntityId::new(env).escaped()
             ));
-        } else {
-            for tool in tools {
-                policies.push(format!(
-                    "forbid(\n  principal,\n  {},\n  resource\n) when {{ context.session has \"environment\" && context.session.environment == \"{}\" }};",
+            } else {
+                for tool in tools {
+                    // forbid if environment not provided for this action, or environment is the denied one
+                    policies.push(format!(
+                    "forbid(\n  principal,\n  {},\n  resource\n) when {{ !(context.session has \"environment\") || context.session.environment == \"{}\" }};",
                     action_ref(ns, tool),
                     EntityId::new(env).escaped()
                 ));
-            }
-        }
-    }
-    policies
-}
-
-fn generate_consent_policies(config: &CedarAgentConfig) -> Vec<String> {
-    let consent = match &config.consent {
-        Some(c) => c,
-        None => return Vec::new(),
-    };
-    let ns = &config.namespace;
-    let mut policies = Vec::new();
-
-    for (tool, scope) in consent {
-        let action_clause = action_ref(ns, tool);
-        let roles = normalize_consent_roles(scope);
-        let applicable_roles = get_roles_granting_tool(config, tool);
-        if roles.contains(&"*") {
-            // Collect all roles that actually grant access to this tool
-            for role in &applicable_roles {
-                let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role).escaped());
-                policies.push(format!(
-                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent == true }};",
-                ));
-            }
-        } else {
-            for role in roles {
-                if !applicable_roles.contains(&role) {
-                    // skip adding permit, role does not have access to tool
-                    continue;
                 }
-                let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role).escaped());
-                policies.push(format!(
-                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent == true }};",
-                ));
             }
+
+            self.policies_text.append(&mut policies);
         }
     }
-    policies
+
+    fn generate_consent_policies(&mut self) {
+        let consent = match &self.config.consent {
+            Some(c) => c,
+            None => return,
+        };
+        let ns = &self.config.namespace;
+        let mut policies = Vec::new();
+
+        for (tool, scope) in consent {
+            let action_clause = action_ref(ns, tool);
+            let roles = normalize_consent_roles(scope);
+            if roles.contains(&"*") {
+                // Collect all roles that actually grant access to this tool
+                // (either explicitly or via wildcard "*").
+                let applicable_roles = get_roles_granting_tool(self.config, tool);
+                for role in &applicable_roles {
+                    let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role).escaped());
+                    policies.push(format!(
+                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent }};",
+                ));
+                }
+            } else {
+                for role in &roles {
+                    let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role).escaped());
+                    policies.push(format!(
+                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent }};",
+                ));
+                }
+            }
+        }
+        self.policies_text.append(&mut policies);
+    }
+
+    pub fn generate_policies(config: &CedarAgentConfig) -> String {
+        let mut generator = PolicyGenerator {
+            config,
+            policies_text: Vec::new(),
+        };
+        generator.generate_role_policies();
+        generator.generate_restriction_policies();
+        generator.generate_rate_limit_policies();
+        generator.generate_time_window_policies();
+        generator.generate_env_denial_policies();
+        generator.generate_consent_policies();
+
+        generator.policies_text.join("\n\n")
+    }
 }
 
 fn format_cedar_value(v: &serde_json::Value) -> String {
@@ -249,17 +277,6 @@ fn format_cedar_value(v: &serde_json::Value) -> String {
         serde_json::Value::Bool(b) => b.to_string(),
         _ => format!("\"{}\"", EntityId::new(v.to_string()).escaped()),
     }
-}
-
-pub fn generate_policies(config: &CedarAgentConfig) -> String {
-    let mut all: Vec<String> = Vec::new();
-    all.extend(generate_role_policies(config));
-    all.extend(generate_restriction_policies(config));
-    all.extend(generate_rate_limit_policies(config));
-    all.extend(generate_time_window_policies(config));
-    all.extend(generate_env_denial_policies(config));
-    all.extend(generate_consent_policies(config));
-    all.join("\n\n")
 }
 
 #[cfg(test)]
@@ -290,7 +307,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
             "permit(principal in Agent::Role::\"analyst\", action == Agent::Action::\"search\", resource);"
@@ -309,7 +326,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains("permit(principal in Agent::Role::\"admin\", action, resource);"));
     }
@@ -331,7 +348,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
             "forbid(\n  principal,\n  action == Agent::Action::\"query_database\",\n  resource\n) when {\n  !(context.input has \"database\" && (context.input[\"database\"] == \"analytics\" || context.input[\"database\"] == \"reporting\"))\n};"
@@ -344,10 +361,10 @@ mod tests {
             rate_limits: Some(BTreeMap::from([("send_email".to_string(), 3)])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
-            "forbid(\n  principal,\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"call_count_send_email\" && context.session.call_count_send_email >= 3 };"
+            "forbid(\n  principal,\n  action == Agent::Action::\"send_email\",\n  resource\n) when { !(context.session has \"call_count_send_email\") || context.session.call_count_send_email >= 3 };"
         ));
     }
 
@@ -357,10 +374,10 @@ mod tests {
             rate_limits: Some(BTreeMap::from([("*".to_string(), 100)])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
-            "forbid(\n  principal,\n  action,\n  resource\n) when { context.session has \"call_count\" && context.session.call_count >= 100 };"
+            "forbid(\n  principal,\n  action,\n  resource\n) when { !(context.session has \"call_count\") || context.session.call_count >= 100 };"
         ));
     }
 
@@ -376,10 +393,10 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
-            "forbid(\n  principal,\n  action,\n  resource\n) when { context.session has \"hour_utc\" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };"
+            "forbid(\n  principal,\n  action,\n  resource\n) when { !(context.session has \"hour_utc\") || (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };"
         ));
     }
 
@@ -395,10 +412,10 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
-            "forbid(\n  principal,\n  action == Agent::Action::\"deploy\",\n  resource\n) when { context.session has \"hour_utc\" && (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };"
+            "forbid(\n  principal,\n  action == Agent::Action::\"deploy\",\n  resource\n) when { !(context.session has \"hour_utc\") || (context.session.hour_utc < 9 || context.session.hour_utc >= 17) };"
         ));
     }
 
@@ -411,10 +428,10 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
-            "forbid(\n  principal,\n  action == Agent::Action::\"delete_record\",\n  resource\n) when { context.session has \"environment\" && context.session.environment == \"production\" };"
+            "forbid(\n  principal,\n  action == Agent::Action::\"delete_record\",\n  resource\n) when { !(context.session has \"environment\") || context.session.environment == \"production\" };"
         ));
     }
 
@@ -434,14 +451,14 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         // The consent permit must be scoped to roles that grant the tool
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
         ));
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
         ));
         // Must NOT have an unconstrained principal permit
         assert!(!policies.contains(
@@ -452,20 +469,16 @@ mod tests {
     #[test]
     fn test_consent_specific_role() {
         let config = CedarAgentConfig {
-            roles: Some(BTreeMap::from([(
-                "analyst".to_string(),
-                vec!["search".to_string(), "send_email".to_string()],
-            )])),
             consent: Some(BTreeMap::from([(
                 "send_email".to_string(),
                 ConsentScope::SpecificRoles(vec!["analyst".to_string()]),
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
         ));
     }
 
@@ -482,7 +495,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         // send_email should NOT appear in the unconditional role permit
         assert!(!policies.contains(
@@ -494,7 +507,7 @@ mod tests {
         ));
         // consent permit for send_email should be scoped to analyst
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
         ));
     }
 
@@ -511,19 +524,19 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains("!(action == Agent::Action::\"send_email\")"));
         // Consent permit must be scoped to admin role (which grants * tools)
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
         ));
     }
 
     #[test]
     fn test_empty_config_produces_no_policies() {
         let config = CedarAgentConfig::default();
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert!(policies.is_empty());
     }
 
@@ -533,7 +546,7 @@ mod tests {
             roles: Some(BTreeMap::from([("empty".to_string(), vec![])])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert!(policies.is_empty());
     }
 
@@ -546,7 +559,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains("Agent::Action::\"tool\\\"inject\""));
         assert!(policies.contains("Agent::Role::\"role\\\"evil\""));
@@ -566,7 +579,7 @@ mod tests {
             rate_limits: Some(BTreeMap::from([("my.tool-v2".to_string(), 10)])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains("call_count_my_tool_v2"));
         assert!(!policies.contains("call_count_my.tool-v2"));
@@ -592,7 +605,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
             "forbid(\n  principal,\n  action == Agent::Action::\"dangerous_tool\",\n  resource\n);"
@@ -608,7 +621,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains("action,"));
         assert!(policies.contains("\"staging\""));
@@ -623,7 +636,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert!(policies.is_empty());
     }
 
@@ -638,7 +651,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert!(policies.is_empty());
     }
 
@@ -659,106 +672,19 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         // analyst has send_email → should get consent permit
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
         ));
         // viewer does NOT have send_email → must NOT get consent permit for send_email
         assert!(!policies.contains(
-            "permit(\n  principal in Agent::Role::\"viewer\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
+            "permit(\n  principal in Agent::Role::\"viewer\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
         ));
         // No unconstrained permit
         assert!(!policies.contains(
             "permit(\n  principal,\n  action == Agent::Action::\"send_email\",\n  resource\n)"
-        ));
-    }
-
-    #[test]
-    fn test_consent_specific_roles_does_not_grant_access_to_nonexistent_tool() {
-        // Regression: consent_for_roles("delete", &["viewer"]) must NOT grant
-        // the viewer role access to "delete" when the viewer role only has "read".
-        // Consent should restrict, never escalate.
-        let config = CedarAgentConfig {
-            roles: Some(BTreeMap::from([
-                ("viewer".to_string(), vec!["read".to_string()]),
-                (
-                    "admin".to_string(),
-                    vec!["read".to_string(), "delete".to_string()],
-                ),
-            ])),
-            consent: Some(BTreeMap::from([(
-                "delete".to_string(),
-                ConsentScope::SpecificRoles(vec!["viewer".to_string(), "admin".to_string()]),
-            )])),
-            ..Default::default()
-        };
-        let policies = generate_policies(&config);
-        assert_valid_cedar(&policies);
-        // viewer does NOT have "delete" in its tools → must NOT get a consent permit for delete
-        assert!(
-            !policies.contains(
-                "principal in Agent::Role::\"viewer\",\n  action == Agent::Action::\"delete\""
-            ),
-            "viewer should NOT gain 'delete' access via consent; policies:\n{policies}"
-        );
-        // admin DOES have "delete" → should get the consent permit
-        assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"delete\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
-        ));
-        // admin's unconditional permit for "delete" should be excluded (consent takes over)
-        assert!(!policies.contains(
-            "permit(principal in Agent::Role::\"admin\", action == Agent::Action::\"delete\", resource);"
-        ));
-    }
-
-    #[test]
-    fn test_consent_specific_roles_no_roles_have_tool() {
-        // If none of the specified roles grant the tool, no consent policies should be emitted.
-        let config = CedarAgentConfig {
-            roles: Some(BTreeMap::from([(
-                "viewer".to_string(),
-                vec!["read".to_string()],
-            )])),
-            consent: Some(BTreeMap::from([(
-                "delete".to_string(),
-                ConsentScope::SpecificRoles(vec!["viewer".to_string()]),
-            )])),
-            ..Default::default()
-        };
-        let policies = generate_policies(&config);
-        assert_valid_cedar(&policies);
-        // No consent permit for delete should exist at all
-        assert!(
-            !policies.contains("Action::\"delete\""),
-            "no policies should reference 'delete' since no role grants it; policies:\n{policies}"
-        );
-    }
-
-    #[test]
-    fn test_consent_specific_roles_wildcard_role_grants_all_tools() {
-        // A role with "*" grants access to all tools, so consent should apply.
-        let config = CedarAgentConfig {
-            roles: Some(BTreeMap::from([
-                ("admin".to_string(), vec!["*".to_string()]),
-                ("viewer".to_string(), vec!["read".to_string()]),
-            ])),
-            consent: Some(BTreeMap::from([(
-                "deploy".to_string(),
-                ConsentScope::SpecificRoles(vec!["admin".to_string(), "viewer".to_string()]),
-            )])),
-            ..Default::default()
-        };
-        let policies = generate_policies(&config);
-        assert_valid_cedar(&policies);
-        // admin has "*" so it grants "deploy" → consent permit should exist
-        assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"deploy\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent == true };"
-        ));
-        // viewer only has "read" → no consent permit for deploy
-        assert!(!policies.contains(
-            "principal in Agent::Role::\"viewer\",\n  action == Agent::Action::\"deploy\""
         ));
     }
 
@@ -776,7 +702,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let policies = generate_policies(&config);
+        let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains("context.input[\"limit\"] == 100"));
         assert!(policies.contains("context.input[\"limit\"] == 500"));

--- a/rust/cedar-policy-agent-builder/src/policy.rs
+++ b/rust/cedar-policy-agent-builder/src/policy.rs
@@ -1,6 +1,6 @@
 use crate::config::{CedarAgentConfig, ConsentScope};
 use cedar_policy::EntityId;
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, io::ErrorKind::ConnectionRefused};
 
 fn action_ref(ns: &str, name: &str) -> String {
     let eid = EntityId::new(name);
@@ -25,7 +25,7 @@ fn normalize_consent_roles(scope: &ConsentScope) -> Vec<&str> {
 /// Get the roles that grant access to the given `tool`.
 /// A role grants access to a tool if either it grants access to any tool via `"*"` or it
 /// grants access to that specific tool.
-fn get_roles_granting_tool(config: &CedarAgentConfig, tool: &str) -> Vec<String> {
+fn get_roles_granting_tool<'a>(config: &'a CedarAgentConfig, tool: &str) -> Vec<&'a str> {
     let roles = match &config.roles {
         Some(r) => r,
         None => return Vec::new(),
@@ -33,7 +33,7 @@ fn get_roles_granting_tool(config: &CedarAgentConfig, tool: &str) -> Vec<String>
     roles
         .iter()
         .filter(|(_, tools)| tools.iter().any(|t| t == "*" || t == tool))
-        .map(|(role_name, _)| role_name.clone())
+        .map(|(role_name, _)| role_name.as_str())
         .collect()
 }
 
@@ -232,21 +232,24 @@ impl<'a> PolicyGenerator<'a> {
         for (tool, scope) in consent {
             let action_clause = action_ref(ns, tool);
             let roles = normalize_consent_roles(scope);
+            let applicable_roles = get_roles_granting_tool(self.config, tool);
             if roles.contains(&"*") {
                 // Collect all roles that actually grant access to this tool
                 // (either explicitly or via wildcard "*").
-                let applicable_roles = get_roles_granting_tool(self.config, tool);
                 for role in &applicable_roles {
                     let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role).escaped());
                     policies.push(format!(
-                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent }};",
+                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has user_consent && context.session.user_consent }};",
                 ));
                 }
             } else {
                 for role in &roles {
+                    if !applicable_roles.contains(role) {
+                        continue;
+                    }
                     let role_ref = format!("{ns}::Role::\"{}\"", EntityId::new(role).escaped());
                     policies.push(format!(
-                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has \"user_consent\" && context.session.user_consent }};",
+                    "permit(\n  principal in {role_ref},\n  {action_clause},\n  resource\n) when {{ context.session has user_consent && context.session.user_consent }};",
                 ));
                 }
             }
@@ -455,10 +458,10 @@ mod tests {
         assert_valid_cedar(&policies);
         // The consent permit must be scoped to roles that grant the tool
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has user_consent && context.session.user_consent };"
         ));
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
+            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has user_consent && context.session.user_consent };"
         ));
         // Must NOT have an unconstrained principal permit
         assert!(!policies.contains(
@@ -469,6 +472,10 @@ mod tests {
     #[test]
     fn test_consent_specific_role() {
         let config = CedarAgentConfig {
+            roles: Some(BTreeMap::from([(
+                "analyst".to_string(),
+                vec!["send_email".to_string()],
+            )])),
             consent: Some(BTreeMap::from([(
                 "send_email".to_string(),
                 ConsentScope::SpecificRoles(vec!["analyst".to_string()]),
@@ -478,7 +485,7 @@ mod tests {
         let policies = PolicyGenerator::generate_policies(&config);
         assert_valid_cedar(&policies);
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has user_consent && context.session.user_consent };"
         ));
     }
 
@@ -507,7 +514,7 @@ mod tests {
         ));
         // consent permit for send_email should be scoped to analyst
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has user_consent && context.session.user_consent };"
         ));
     }
 
@@ -529,7 +536,7 @@ mod tests {
         assert!(policies.contains("!(action == Agent::Action::\"send_email\")"));
         // Consent permit must be scoped to admin role (which grants * tools)
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
+            "permit(\n  principal in Agent::Role::\"admin\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has user_consent && context.session.user_consent };"
         ));
     }
 
@@ -676,11 +683,11 @@ mod tests {
         assert_valid_cedar(&policies);
         // analyst has send_email → should get consent permit
         assert!(policies.contains(
-            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
+            "permit(\n  principal in Agent::Role::\"analyst\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has user_consent && context.session.user_consent };"
         ));
         // viewer does NOT have send_email → must NOT get consent permit for send_email
         assert!(!policies.contains(
-            "permit(\n  principal in Agent::Role::\"viewer\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has \"user_consent\" && context.session.user_consent };"
+            "permit(\n  principal in Agent::Role::\"viewer\",\n  action == Agent::Action::\"send_email\",\n  resource\n) when { context.session has user_consent && context.session.user_consent };"
         ));
         // No unconstrained permit
         assert!(!policies.contains(

--- a/rust/cedar-policy-agent-builder/tests/authorization.rs
+++ b/rust/cedar-policy-agent-builder/tests/authorization.rs
@@ -254,7 +254,7 @@ fn test_env_denial_blocks_in_production() {
 }
 
 #[test]
-fn test_env_denial_blocks_when_not_provded() {
+fn test_env_denial_blocks_when_not_provided() {
     let result = CedarAgentPolicyBuilder::new()
         .role("admin", &["*"])
         .user("alice", &["admin"])

--- a/rust/cedar-policy-agent-builder/tests/authorization.rs
+++ b/rust/cedar-policy-agent-builder/tests/authorization.rs
@@ -143,6 +143,29 @@ fn test_rate_limit_denies_when_exceeded() {
 }
 
 #[test]
+fn test_rate_limit_denies_when_not_provided() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("user", &["send_email"])
+        .user("alice", &["user"])
+        .rate_limit("send_email", 5)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let count_not_provided = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"send_email\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {}}),
+    );
+    assert_eq!(count_not_provided, cedar_policy::Decision::Deny);
+}
+
+#[test]
 fn test_time_window_denies_outside_hours() {
     let result = CedarAgentPolicyBuilder::new()
         .role("user", &["deploy"])
@@ -176,6 +199,29 @@ fn test_time_window_denies_outside_hours() {
 }
 
 #[test]
+fn test_time_window_denies_when_not_provided() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("user", &["deploy"])
+        .user("alice", &["user"])
+        .time_window("deploy", (9, 17))
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let hour_not_provided = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"deploy\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {}}),
+    );
+    assert_eq!(hour_not_provided, cedar_policy::Decision::Deny);
+}
+
+#[test]
 fn test_env_denial_blocks_in_production() {
     let result = CedarAgentPolicyBuilder::new()
         .role("admin", &["*"])
@@ -205,6 +251,28 @@ fn test_env_denial_blocks_in_production() {
         serde_json::json!({"session": {"environment": "staging"}}),
     );
     assert_eq!(in_staging, cedar_policy::Decision::Allow);
+}
+
+#[test]
+fn test_env_denial_blocks_when_not_provded() {
+    let result = CedarAgentPolicyBuilder::new()
+        .role("admin", &["*"])
+        .user("alice", &["admin"])
+        .deny_in_env("production", &["delete"])
+        .build()
+        .unwrap();
+
+    let entities_json = entities_to_json(&result.entities);
+
+    let env_not_provided = authorize(
+        &result.policies,
+        &entities_json,
+        "Agent::User::\"alice\"",
+        "Agent::Action::\"delete\"",
+        "Agent::Resource::\"default\"",
+        serde_json::json!({"session": {"hour_utc": "12"}}),
+    );
+    assert_eq!(env_not_provided, cedar_policy::Decision::Deny);
 }
 
 #[test]

--- a/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/generator/request.rs
@@ -549,7 +549,7 @@ impl RequestGenerator {
                 let tags = into_pairs(additional_properties, &mut entities)?;
 
                 if tags.is_empty() && self.config.objects_as_records {
-                    Ok((RestrictedExpr::record(pairs.into_iter())?, entities))
+                    Ok((RestrictedExpr::record(pairs)?, entities))
                 } else {
                     // Check if this object was deduplicated to a different namespace.
                     let qualified_ty = self.resolved_ty(ty_name, namespace)?;


### PR DESCRIPTION
Change the forbid policies that are added for time-window / env-denial / rate-limit to result in deny when the session data is not provided in the request.

Also wrapped the policy generation in a `PolicyGenerator` struct. It's not very useful right now, but I when thinking about this problem I was thinking of using some state to add additional `forbid` policies after the fact. This solution is cleaner,  but I think we may still need to keep track of additional state if we extend the policy generation capabilities.

Review with "hide whitespace" to get a better display of changes.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to any crates in this repository (e.g., changes to the signature of an existing API).
  * List all crates requiring a major version bump here
- [ ] A backwards-compatible change requiring a minor version bump to any crates in this repository (e.g., addition of a new API).
  * List all crates requiring a minor version bump here
- [ ] A bug fix or other functionality change requiring a patch to any crates.
- [ ] A change "invisible" to users (e.g., documentation, changes to non public-facing "internal" APIs)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.