### PR TITLE
Fix missing resource diagnostic in authorize CLI

### DIFF
--- a/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
+++ b/rust/cedar-policy-mcp-schema-generator/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `SchemaGenerator` now stays in a good state even when `add_actions_from_server_description` / `add_action_from_tool_description` fails due to malformed tool descriptions.
+- The `authorize` command now reports the correct diagnostic code and help text when the resource argument is missing.
 
 ## [0.6.0] - 2026-05-26
 

--- a/rust/cedar-policy-mcp-schema-generator/src/cli/err.rs
+++ b/rust/cedar-policy-mcp-schema-generator/src/cli/err.rs
@@ -85,8 +85,8 @@ pub enum CliError {
     MissingPrincipal,
     #[error("Missing required resource argument")]
     #[diagnostic(
-        code(cli_error::missing_principal),
-        help("Provide a principal, e.g., using `--resource ResourceType::\"resource_id\".")
+        code(cli_error::missing_resource),
+        help("provide a resource with `--resource ResourceType::\"resource_id\"`")
     )]
     MissingResource,
     #[error("Could not open cedar context file `{}`: {}", .0.file.display(), .0.error)]
@@ -142,5 +142,24 @@ impl CliError {
 
     pub(crate) fn request_json_file_open(file: PathBuf, error: std::io::Error) -> Self {
         Self::RequestFileOpen(FileOpenError { file, error })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CliError;
+    use miette::Diagnostic;
+
+    #[test]
+    fn missing_resource_has_resource_specific_diagnostic() {
+        let error = CliError::MissingResource;
+        let code = error.code().map(|code| code.to_string());
+        let help = error.help().map(|help| help.to_string());
+
+        assert_eq!(code.as_deref(), Some("cli_error::missing_resource"));
+        assert_eq!(
+            help.as_deref(),
+            Some("provide a resource with `--resource ResourceType::\"resource_id\"`")
+        );
     }
 }


### PR DESCRIPTION
## Description of changes

The `authorize` command returns `MissingResource` when the resource argument is absent. The diagnostic used `cli_error::missing_principal` and told the user to provide a principal.

This change uses `cli_error::missing_resource` and provides resource-specific help. It also adds a unit test and updates the Unreleased changelog.

## Issue #, if available

None. This is a small, local fix.

## Tests

- `cargo fmt --all --check`
- `cargo test -p cedar-policy-mcp-schema-generator --features cli missing_resource_has_resource_specific_diagnostic`
- `cargo clippy --all-features`

## Checklist for requesting a review

The change in this PR is:

- [x] A bug fix or other functionality change requiring a patch to any crates.

I confirm that this PR:

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change.